### PR TITLE
feat: enrich coroutine event telemetry

### DIFF
--- a/compiler/bytecode.py
+++ b/compiler/bytecode.py
@@ -1,5 +1,22 @@
-from enum import Enum, auto
+from __future__ import annotations
+
 from dataclasses import dataclass
+from enum import Enum, auto
+
+
+@dataclass(frozen=True)
+class SourceLocation:
+    file: str
+    line: int
+    column: int
+
+
+@dataclass(frozen=True)
+class InstructionDebug:
+    """Metadata describing the provenance of an instruction."""
+
+    location: SourceLocation
+    function_name: str
 
 class Opcode(Enum):
     LOAD_IMM = auto()     # LOAD_IMM reg, value
@@ -88,6 +105,7 @@ class Opcode(Enum):
 class Instruction:
     opcode: Opcode
     args: list  # e.g., ['a', 'b'] or ['x', 5]
+    debug: InstructionDebug | None = None
 
     def __str__(self):
         return f"{self.opcode.name} {' '.join(map(str, self.args))}"

--- a/compiler/bytecode.py
+++ b/compiler/bytecode.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 from dataclasses import dataclass
 from enum import Enum, auto
 
@@ -17,6 +15,7 @@ class InstructionDebug:
 
     location: SourceLocation
     function_name: str
+
 
 class Opcode(Enum):
     LOAD_IMM = auto()     # LOAD_IMM reg, value
@@ -83,7 +82,7 @@ class Opcode(Enum):
     SHL = auto()
     SHR = auto()
     SAR = auto()
-    
+
         # 数组支持
     ARR_INIT = auto()
     ARR_SET = auto()

--- a/compiler/vm_errors.py
+++ b/compiler/vm_errors.py
@@ -1,0 +1,16 @@
+from __future__ import annotations
+
+from typing import Sequence
+
+from .vm_events import TraceFrame
+
+
+class VMRuntimeError(RuntimeError):
+    """Runtime error raised by the bytecode VM with attached traceback frames."""
+
+    def __init__(self, message: str, frames: Sequence[TraceFrame]):
+        super().__init__(message)
+        self.frames = list(frames)
+
+
+__all__ = ["VMRuntimeError"]

--- a/compiler/vm_events.py
+++ b/compiler/vm_events.py
@@ -1,0 +1,93 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, List, Mapping, Sequence
+
+
+@dataclass(frozen=True)
+class TraceFrame:
+    """Represents a single frame in a Lua-style traceback."""
+
+    function_name: str
+    file: str
+    line: int
+    column: int
+    pc: int
+    coroutine_id: int | None = None
+
+
+@dataclass(frozen=True)
+class CoroutineCreated:
+    coroutine_id: int
+    parent_id: int | None
+    function_name: str | None
+    args: Sequence[Any]
+    upvalues: Sequence[Any]
+    pc: int
+    stack: Sequence[TraceFrame]
+    timestamp: float
+
+
+@dataclass(frozen=True)
+class CoroutineResumed:
+    coroutine_id: int
+    args: Sequence[Any]
+    pc: int
+    stack: Sequence[TraceFrame]
+    coroutine_pc: int | None
+    coroutine_stack: Sequence[TraceFrame]
+    timestamp: float
+
+
+@dataclass(frozen=True)
+class CoroutineYielded:
+    coroutine_id: int
+    values: Sequence[Any]
+    pc: int
+    stack: Sequence[TraceFrame]
+    timestamp: float
+
+
+@dataclass(frozen=True)
+class CoroutineCompleted:
+    coroutine_id: int
+    values: Sequence[Any]
+    error: str | None
+    pc: int
+    stack: Sequence[TraceFrame]
+    timestamp: float
+
+
+CoroutineEvent = CoroutineCreated | CoroutineResumed | CoroutineYielded | CoroutineCompleted
+
+
+@dataclass
+class CoroutineSnapshot:
+    coroutine_id: int
+    status: str
+    last_yield: List[Any]
+    last_error: str | None
+    last_resume: List[Any] = field(default_factory=list)
+    call_stack: List[TraceFrame] = field(default_factory=list)
+
+
+@dataclass
+class VMStateSnapshot:
+    pc: int
+    current_coroutine: int | None
+    registers: Mapping[str, Any]
+    stack: Sequence[Any]
+    call_stack: Sequence[TraceFrame]
+    coroutines: Sequence[CoroutineSnapshot] = field(default_factory=list)
+
+
+__all__ = [
+    "CoroutineCreated",
+    "CoroutineResumed",
+    "CoroutineYielded",
+    "CoroutineCompleted",
+    "CoroutineEvent",
+    "CoroutineSnapshot",
+    "TraceFrame",
+    "VMStateSnapshot",
+]

--- a/compiler/vm_visualizer.py
+++ b/compiler/vm_visualizer.py
@@ -1,15 +1,30 @@
-import pygame
-import sys
-import json
 import datetime
-from typing import List, Dict, Any, Tuple, Set
+import json
+import sys
+from typing import Any, Dict, List, Sequence, Set, Tuple
+
+import pygame
 
 try:
     from .bytecode import Instruction
     from .bytecode_vm import BytecodeVM
+    from .vm_events import (
+        CoroutineCompleted,
+        CoroutineCreated,
+        CoroutineEvent,
+        CoroutineResumed,
+        CoroutineYielded,
+    )
 except Exception:  # fallback when run as top-level script
     from compiler.bytecode import Instruction  # type: ignore
     from compiler.bytecode_vm import BytecodeVM  # type: ignore
+    from compiler.vm_events import (  # type: ignore
+        CoroutineCompleted,
+        CoroutineCreated,
+        CoroutineEvent,
+        CoroutineResumed,
+        CoroutineYielded,
+    )
 
 # Constants
 SCREEN_WIDTH = 1600
@@ -40,6 +55,7 @@ class VMVisualizer:
         self.search_query = ""
         self.message = "Press P to run, SPACE to step, / to search."
         self.trace_log: List[Dict[str, Any]] = []
+        self.event_log: List[str] = []
         self._vm_cls = type(vm)
         # Keep a frozen copy of instructions for resetting
         self._instructions = list(vm.instructions)
@@ -84,12 +100,98 @@ class VMVisualizer:
         except TypeError:
             return str(value)
 
+    def _stack_summary(self, stack: Sequence["TraceFrame"]) -> str:
+        if not stack:
+            return "∅"
+        top = stack[0]
+        return f"{top.function_name}@{top.file}:{top.line}"
+
+    def _consume_events(self) -> None:
+        events = self.vm.drain_events()
+        for event in events:
+            self.event_log.append(self._format_event(event))
+        if len(self.event_log) > 200:
+            self.event_log = self.event_log[-200:]
+
+    def _format_event(self, event: CoroutineEvent) -> str:
+        if isinstance(event, CoroutineCreated):
+            name = event.function_name or "<function>"
+            parent = f" parent={event.parent_id}" if event.parent_id is not None else ""
+            stack = self._stack_summary(event.stack)
+            payload = ""
+            if event.upvalues:
+                payload = f" upvalues={self._format_value(list(event.upvalues))}"
+            return (
+                f"created coroutine #{event.coroutine_id} ({name})"
+                f" pc={event.pc}{parent} stack={stack}{payload}"
+            )
+        if isinstance(event, CoroutineResumed):
+            scheduler_stack = self._stack_summary(event.stack)
+            target = (
+                f" next_pc={event.coroutine_pc}" if event.coroutine_pc is not None else ""
+            )
+            target_stack = (
+                f" target={self._stack_summary(event.coroutine_stack)}"
+                if event.coroutine_stack
+                else ""
+            )
+            return (
+                f"resume coroutine #{event.coroutine_id} "
+                f"args={self._format_value(list(event.args))} "
+                f"pc={event.pc} stack={scheduler_stack}{target}{target_stack}"
+            )
+        if isinstance(event, CoroutineYielded):
+            values = self._format_value(list(event.values))
+            stack = self._stack_summary(event.stack)
+            return (
+                f"yield from #{event.coroutine_id} values={values} "
+                f"pc={event.pc} stack={stack}"
+            )
+        if isinstance(event, CoroutineCompleted):
+            stack = self._stack_summary(event.stack)
+            if event.error:
+                return (
+                    f"coroutine #{event.coroutine_id} error: {event.error} "
+                    f"pc={event.pc} stack={stack}"
+                )
+            return (
+                f"coroutine #{event.coroutine_id} done "
+                f"values={self._format_value(list(event.values))} "
+                f"pc={event.pc} stack={stack}"
+            )
+        return str(event)
+
     def _prepare_data(self):
         instructions_data, highlight_idx, match_highlights = self._prepare_instruction_display()
 
         registers_data, changed_indices = self._prepare_register_display()
 
-        stack_data = [f"PC={pc}, Params={params}, Regs=..." for pc, params, _ in self.vm.call_stack]
+        snapshot = self.vm.snapshot_state()
+        stack_data = [
+            f"{frame.function_name} @ {frame.file}:{frame.line} (pc={frame.pc})"
+            for frame in snapshot.call_stack
+        ]
+
+        coroutine_data: List[str] = []
+        current_index = -1
+        for idx, coro in enumerate(snapshot.coroutines):
+            status = coro.status
+            yield_display = self._format_value(coro.last_yield)
+            resume_display = self._format_value(coro.last_resume)
+            stack_depth = len(coro.call_stack)
+            stack_summary = self._stack_summary(coro.call_stack)
+            line = (
+                f"#{coro.coroutine_id} {status:<10} "
+                f"resume={resume_display} yield={yield_display} "
+                f"stack[{stack_depth}]={stack_summary}"
+            )
+            if coro.last_error:
+                line += f" error={coro.last_error}"
+            coroutine_data.append(line)
+            if snapshot.current_coroutine == coro.coroutine_id:
+                current_index = idx
+
+        self._consume_events()
 
         output_data = [self._format_value(item) for item in self.vm.output]
 
@@ -104,6 +206,9 @@ class VMVisualizer:
             stack_data,
             output_data,
             emit_stack_data,
+            coroutine_data,
+            current_index,
+            list(self.event_log[-30:]),
         )
 
     def _prepare_instruction_display(self) -> Tuple[List[str], int, Set[int]]:
@@ -166,6 +271,9 @@ class VMVisualizer:
             stack_data,
             output_data,
             emit_stack_data,
+            coroutine_data,
+            coroutine_highlight,
+            event_log,
         ) = self._prepare_data()
 
         # Instructions
@@ -197,10 +305,40 @@ class VMVisualizer:
         self._draw_section("Call Stack", stack_data, 640, 440, 450, 200)
 
         # Emit Stack
-        self._draw_section("Emit Stack", emit_stack_data, 640, 660, 450, SCREEN_HEIGHT - 660 - MARGIN)
+        emit_y = 660
+        emit_height = 120
+        self._draw_section("Emit Stack", emit_stack_data, 640, emit_y, 450, emit_height)
 
-        # Output
-        self._draw_section("Output", output_data, 1110, MARGIN, SCREEN_WIDTH - 1110 - MARGIN, SCREEN_HEIGHT - 2 * MARGIN)
+        # Output below emit stack
+        output_y = emit_y + emit_height + 20
+        output_height = SCREEN_HEIGHT - output_y - MARGIN
+        self._draw_section("Output", output_data, 640, output_y, 450, output_height)
+
+        # Coroutines panel on right
+        right_x = 1110
+        right_width = SCREEN_WIDTH - right_x - MARGIN
+        coroutine_height = 240
+        self._draw_section(
+            "Coroutines",
+            coroutine_data or ["<none>"],
+            right_x,
+            MARGIN,
+            right_width,
+            coroutine_height,
+            highlight_index=coroutine_highlight,
+        )
+
+        # Coroutine events below
+        events_y = MARGIN + coroutine_height + 20
+        events_height = SCREEN_HEIGHT - events_y - MARGIN
+        self._draw_section(
+            "Coroutine Events",
+            list(reversed(event_log)) or ["<no events>"],
+            right_x,
+            events_y,
+            right_width,
+            events_height,
+        )
 
         # Status/Help
         status_text = "PAUSED" if self.paused else "RUNNING"

--- a/compiler/vm_visualizer_headless.py
+++ b/compiler/vm_visualizer_headless.py
@@ -3,12 +3,26 @@ from __future__ import annotations
 import curses
 import json
 from dataclasses import dataclass
-from typing import Any, List, Optional
+from typing import Any, List, Optional, Sequence
 
 try:
     from .bytecode_vm import BytecodeVM, Instruction
+    from .vm_events import (
+        CoroutineCompleted,
+        CoroutineCreated,
+        CoroutineEvent,
+        CoroutineResumed,
+        CoroutineYielded,
+    )
 except Exception:  # pragma: no cover - fallback when run as script bundle
     from compiler.bytecode_vm import BytecodeVM, Instruction  # type: ignore
+    from compiler.vm_events import (  # type: ignore
+        CoroutineCompleted,
+        CoroutineCreated,
+        CoroutineEvent,
+        CoroutineResumed,
+        CoroutineYielded,
+    )
 
 
 @dataclass
@@ -38,6 +52,7 @@ class VMVisualizer:
         self.auto_run = False
         self.message = "Press SPACE to run/pause, n to step, q to quit."
         self.state.vm.index_labels()
+        self.event_log: List[str] = []
 
     # ---------------------------- public API ----------------------------- #
     def run(self) -> None:  # pragma: no cover - interactive utility
@@ -94,11 +109,67 @@ class VMVisualizer:
         elif auto:
             self.message = "Running..."
 
+    def _consume_events(self) -> None:
+        events = self.state.vm.drain_events()
+        for event in events:
+            self.event_log.append(self._format_event(event))
+        if len(self.event_log) > 200:
+            self.event_log = self.event_log[-200:]
+
+    def _stack_summary(self, stack: Sequence["TraceFrame"]) -> str:
+        if not stack:
+            return "∅"
+        top = stack[0]
+        return f"{top.function_name}@{top.file}:{top.line}"
+
+    def _format_event(self, event: CoroutineEvent) -> str:
+        if isinstance(event, CoroutineCreated):
+            name = event.function_name or "<function>"
+            parent = f" parent={event.parent_id}" if event.parent_id is not None else ""
+            stack = self._stack_summary(event.stack)
+            extra = ""
+            if event.upvalues:
+                extra = f" upvalues={list(event.upvalues)}"
+            return (
+                f"created #{event.coroutine_id} ({name})"
+                f" pc={event.pc}{parent} stack={stack}{extra}"
+            )
+        if isinstance(event, CoroutineResumed):
+            scheduler_stack = self._stack_summary(event.stack)
+            target = f" next_pc={event.coroutine_pc}" if event.coroutine_pc is not None else ""
+            target_stack = (
+                f" target={self._stack_summary(event.coroutine_stack)}"
+                if event.coroutine_stack
+                else ""
+            )
+            return (
+                f"resume #{event.coroutine_id} args={list(event.args)} "
+                f"pc={event.pc} stack={scheduler_stack}{target}{target_stack}"
+            )
+        if isinstance(event, CoroutineYielded):
+            stack = self._stack_summary(event.stack)
+            return (
+                f"yield #{event.coroutine_id} values={list(event.values)} "
+                f"pc={event.pc} stack={stack}"
+            )
+        if isinstance(event, CoroutineCompleted):
+            if event.error:
+                return (
+                    f"#{event.coroutine_id} error: {event.error} "
+                    f"pc={event.pc} stack={self._stack_summary(event.stack)}"
+                )
+            return (
+                f"#{event.coroutine_id} completed values={list(event.values)} "
+                f"pc={event.pc} stack={self._stack_summary(event.stack)}"
+            )
+        return str(event)
+
     def _reset(self) -> None:
         self.state = _VMState(vm=self._vm_cls(self._program))
         self.state.vm.index_labels()
         self.auto_run = False
         self.message = "Reset. Press SPACE to run or n to step."
+        self.event_log.clear()
 
     def _draw(self, stdscr: "curses._CursesWindow") -> None:
         stdscr.erase()
@@ -132,13 +203,48 @@ class VMVisualizer:
         row += 1
         self._write(stdscr, row, 0, f"Step: {self.state.step} | PC: {self.state.vm.pc} | Auto: {self.auto_run} | Halted: {self.state.halted}")
 
+        snapshot = self.state.vm.snapshot_state()
+        self._consume_events()
+
         row += 2
         self._write(stdscr, row, 0, "Registers:")
-        for i, (name, value) in enumerate(sorted(self.state.vm.registers.items())):
+        for i, (name, value) in enumerate(sorted(snapshot.registers.items())):
             display = self._fmt(value)
             self._write(stdscr, row + 1 + i, 2, f"{name} = {display}")
 
-        row = min(height - 6, row + 3 + len(self.state.vm.registers))
+        row = min(height - 6, row + 3 + len(snapshot.registers))
+        self._write(stdscr, row, 0, "Call stack:")
+        for i, frame in enumerate(snapshot.call_stack):
+            self._write(
+                stdscr,
+                row + 1 + i,
+                2,
+                f"{frame.function_name} @ {frame.file}:{frame.line} (pc={frame.pc})",
+            )
+
+        row = min(height - 6, row + 3 + len(snapshot.call_stack))
+        self._write(stdscr, row, 0, "Coroutines:")
+        if snapshot.coroutines:
+            for i, coro in enumerate(snapshot.coroutines):
+                prefix = "*" if snapshot.current_coroutine == coro.coroutine_id else "-"
+                line = (
+                    f"{prefix} #{coro.coroutine_id} {coro.status} "
+                    f"resume={self._fmt(coro.last_resume)} "
+                    f"yield={self._fmt(coro.last_yield)}"
+                )
+                if coro.last_error:
+                    line += f" error={coro.last_error}"
+                self._write(stdscr, row + 1 + i, 2, line)
+            row += 1 + len(snapshot.coroutines)
+        else:
+            self._write(stdscr, row + 1, 2, "<none>")
+            row += 2
+
+        self._write(stdscr, row, 40, "Events:")
+        for i, line in enumerate(reversed(self.event_log[-5:])):
+            self._write(stdscr, row + 1 + i, 42, line)
+
+        row = min(height - 6, row + 7)
         self._write(stdscr, row, 0, "Emit stack:")
         emit_repr = ", ".join(self._fmt(e) for e in self.state.vm.emit_stack)
         self._write(stdscr, row + 1, 2, emit_repr or "<empty>")

--- a/haifa_lua/cli.py
+++ b/haifa_lua/cli.py
@@ -1,10 +1,22 @@
 from __future__ import annotations
 
 import argparse
+import pathlib
 import sys
 from typing import Optional
 
-from .runtime import run_source, run_script
+from compiler.vm_errors import VMRuntimeError
+from compiler.vm_events import (
+    CoroutineCompleted,
+    CoroutineCreated,
+    CoroutineResumed,
+    CoroutineYielded,
+)
+
+from .debug import as_lua_error, format_traceback
+from .runtime import compile_source, run_source
+from .stdlib import create_default_environment
+from compiler.bytecode_vm import BytecodeVM
 
 
 def main(argv: Optional[list[str]] = None) -> int:
@@ -12,23 +24,137 @@ def main(argv: Optional[list[str]] = None) -> int:
     parser.add_argument("script", nargs="?", help="Path to Lua script (.lua)")
     parser.add_argument("-e", "--execute", dest="inline", help="Execute Lua code string")
     parser.add_argument("--print-output", action="store_true", help="Print VM output array")
+    parser.add_argument("--trace", nargs="?", const="all", help="Enable execution trace (optional filter 'coroutine')")
+    parser.add_argument("--stack", action="store_true", help="Print Lua-style stack traceback on error")
+    parser.add_argument(
+        "--break-on-error",
+        action="store_true",
+        help="Pause for confirmation when an error occurs",
+    )
     args = parser.parse_args(argv)
 
     try:
-        if args.inline:
-            output = run_source(args.inline)
-        elif args.script:
-            output = run_script(args.script)
-        else:
-            parser.error("missing script or --execute")
+        trace_filter = (args.trace or "none").lower()
+        debug_enabled = args.stack or args.break_on_error or trace_filter != "none"
+        if args.inline and args.script:
+            parser.error("cannot use script path and --execute together")
             return 1
+
+        if debug_enabled:
+            if args.inline:
+                source = args.inline
+                source_name = "<inline>"
+            elif args.script:
+                source_name = args.script
+                source = pathlib.Path(args.script).read_text(encoding="utf-8")
+            else:
+                parser.error("missing script or --execute")
+                return 1
+            output = _execute_with_debug(source, source_name, trace_filter, args)
+        else:
+            if args.inline:
+                output = run_source(args.inline, source_name="<inline>")
+            elif args.script:
+                source_text = pathlib.Path(args.script).read_text(encoding="utf-8")
+                output = run_source(source_text, source_name=args.script)
+            else:
+                parser.error("missing script or --execute")
+                return 1
         if args.print_output:
             for item in output:
                 print(item)
         return 0
     except Exception as exc:  # pragma: no cover - CLI surface
+        if isinstance(exc, VMRuntimeError) and args.stack:
+            print(format_traceback(exc.frames), file=sys.stderr)
+        if isinstance(exc, VMRuntimeError) and args.break_on_error:
+            try:
+                input("Execution paused due to error. Press Enter to exit...")
+            except EOFError:
+                pass
         print(f"Lua execution failed: {exc}", file=sys.stderr)
         return 1
+
+
+def _execute_with_debug(source: str, source_name: str, trace_filter: str, args: argparse.Namespace) -> list:
+    instructions = list(compile_source(source, source_name=source_name))
+    env = create_default_environment()
+    vm = BytecodeVM(instructions)
+    vm.lua_env = env
+    vm.registers.update(env.to_vm_registers())
+    debug = trace_filter in {"all", "instructions"}
+    try:
+        vm.run(debug=debug)
+    except VMRuntimeError as exc:
+        raise as_lua_error(exc) from exc
+    env.sync_from_vm(vm.registers)
+    events = vm.drain_events()
+    if trace_filter in {"all", "coroutine"}:
+        _print_events(events)
+    output: list = list(vm.output)
+    if not output and vm.last_return:
+        output = list(vm.last_return)
+    if vm.return_value is not None and not output:
+        output = [vm.return_value]
+    return output
+
+
+def _print_events(events: list) -> None:
+    if not events:
+        return
+    print("Coroutine events:")
+    for event in events:
+        print(f"  - {_format_event(event)}")
+
+
+def _stack_summary(stack) -> str:
+    if not stack:
+        return "∅"
+    frame = stack[0]
+    return f"{frame.function_name}@{frame.file}:{frame.line}"
+
+
+def _format_event(event: object) -> str:
+    if isinstance(event, (CoroutineCreated,)):
+        name = event.function_name or "<function>"
+        parent = f" parent={event.parent_id}" if event.parent_id is not None else ""
+        stack = _stack_summary(event.stack)
+        extra = ""
+        if event.upvalues:
+            extra = f" upvalues={list(event.upvalues)}"
+        return (
+            f"created #{event.coroutine_id} ({name})"
+            f" pc={event.pc}{parent} stack={stack}{extra}"
+        )
+    if isinstance(event, CoroutineResumed):
+        scheduler_stack = _stack_summary(event.stack)
+        target = f" next_pc={event.coroutine_pc}" if event.coroutine_pc is not None else ""
+        target_stack = (
+            f" target={_stack_summary(event.coroutine_stack)}"
+            if event.coroutine_stack
+            else ""
+        )
+        return (
+            f"resume #{event.coroutine_id} args={list(event.args)} "
+            f"pc={event.pc} stack={scheduler_stack}{target}{target_stack}"
+        )
+    if isinstance(event, CoroutineYielded):
+        stack = _stack_summary(event.stack)
+        return (
+            f"yield #{event.coroutine_id} values={list(event.values)} "
+            f"pc={event.pc} stack={stack}"
+        )
+    if isinstance(event, CoroutineCompleted):
+        if event.error:
+            return (
+                f"#{event.coroutine_id} error: {event.error} "
+                f"pc={event.pc} stack={_stack_summary(event.stack)}"
+            )
+        return (
+            f"#{event.coroutine_id} completed values={list(event.values)} "
+            f"pc={event.pc} stack={_stack_summary(event.stack)}"
+        )
+    return str(event)
 
 
 if __name__ == "__main__":  # pragma: no cover

--- a/haifa_lua/debug/__init__.py
+++ b/haifa_lua/debug/__init__.py
@@ -1,0 +1,3 @@
+from .traceback import LuaRuntimeError, as_lua_error, format_lua_error, format_traceback
+
+__all__ = ["LuaRuntimeError", "format_lua_error", "format_traceback", "as_lua_error"]

--- a/haifa_lua/debug/traceback.py
+++ b/haifa_lua/debug/traceback.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 from typing import Sequence
 
 from compiler.vm_errors import VMRuntimeError

--- a/haifa_lua/debug/traceback.py
+++ b/haifa_lua/debug/traceback.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+from typing import Sequence
+
+from compiler.vm_errors import VMRuntimeError
+from compiler.vm_events import TraceFrame
+
+
+def format_lua_error(message: str, frame: TraceFrame | None) -> str:
+    if frame is None:
+        return message
+    return f"{frame.file}:{frame.line}: {message}"
+
+
+def format_traceback(frames: Sequence[TraceFrame]) -> str:
+    lines = ["stack traceback:"]
+    for frame in frames:
+        location = f"{frame.file}:{frame.line}"
+        lines.append(f"\t{location}: in function '{frame.function_name}'")
+    return "\n".join(lines)
+
+
+class LuaRuntimeError(VMRuntimeError):
+    """Specialized runtime error that formats messages like Lua."""
+
+    def __init__(self, message: str, frames: Sequence[TraceFrame]):
+        super().__init__(message, frames)
+        top = frames[0] if frames else None
+        self.lua_message = format_lua_error(message, top)
+
+    def __str__(self) -> str:
+        return self.lua_message
+
+
+def as_lua_error(error: VMRuntimeError) -> LuaRuntimeError:
+    return LuaRuntimeError(str(error), error.frames)
+
+
+__all__ = ["LuaRuntimeError", "format_lua_error", "format_traceback", "as_lua_error"]

--- a/knowledge/09-coroutine-visualizer-and-error-plan.md
+++ b/knowledge/09-coroutine-visualizer-and-error-plan.md
@@ -1,103 +1,166 @@
-# 方案草案：协程可视化与 Lua 风格错误报告
+# 实施计划：协程可视化与 Lua 风格错误调试
 
-本方案分为两部分：
-1. 扩展 VM 可视化器以呈现协程状态与 `resume`/`yield` 事件。
-2. 规划 Lua 风格的错误栈回溯，实现字节码 → 源位置映射，为 CLI 调试模式奠定基础。
+本计划覆盖三个维度：
 
----
+1. **VM 事件钩子与数据采集** —— 为协程行为建立统一的事件流。
+2. **可视化器 UI 升级** —— 利用事件流呈现协程状态、切换视角并改进调试体验。
+3. **Lua 风格栈回溯与 CLI 调试开关** —— 提供与 Lua 一致的错误输出，并在命令行暴露调试级别控制。
 
-## 1. 协程可视化增强
-
-### 1.1 数据流改造
-
-- **BytecodeVM 扩展**
-  - 暴露 `current_coroutine`、`last_event`、`yield_values`、`awaiting_resume` 等状态，通过观察接口（如 `vm.snapshot_state()`）统一输出。
-  - 在 `run(step)` 过程中抛出结构化事件：
-    - `CoroutineCreated(id, label, upvalues)`
-    - `CoroutineResumed(id, args)`
-    - `CoroutineYielded(id, values)`
-    - `CoroutineCompleted(id, results|error)`
-  - 事件对象存入 `vm.emit_stack` 并在视觉层消费，确保现有 jq 功能兼容：若非 Lua 模式，可忽略协程事件。
-
-- **LuaCoroutine 标识**
-  - 每一协程分配自增 `coroutine_id`，保存在 `LuaCoroutine` 与 `BytecodeVM` 中，便于可视化器区分。
-  - Resume 时附带调用栈快照（labels + PC），为 UI 展示提供数据。
-
-### 1.2 可视化 UI 更新
-
-- **State Panel**：新增 "Coroutines" 面板，列表显示：
-  - `ID / status (running|suspended|dead)`
-  - 当前 resume/yield 参数
-  - 函数标签与 upvalue 引用
-- **Timeline (事件流)**：使用现有指令执行时间线，插入协程事件节点；`yield` 节点可高亮指令位置。
-- **Stack View**：
-  - 扩展栈帧展示，对运行中的协程标注来源；
-  - 支持在 UI 中切换查看不同协程的寄存器/upvalue。
-- **交互**：
-  - 允许从协程列表点击切换到对应 VM 状态；
-  - 可选自动跟随当前运行协程。
-
-### 1.3 兼容性与实现步骤
-
-1. 在 `BytecodeVM` 添加事件收集与快照 API，更新 LuaCoroutine 创建/恢复流程以推送事件。
-2. 修改 `vm_visualizer`（GUI/Headless）读取新事件。
-3. 增加测试：
-   - 单元：事件顺序（create → resume → yield → resume → complete）。
-   - 集成：Headless 模式输出包含协程状态。
-4. 文档：更新可视化器指南，说明协程面板与日志格式。
+每个部分均列出目标、关键改动、详细步骤与交付物，以支撑后续迭代落地。
 
 ---
 
-## 2. Lua 风格错误报告规划
+## 1. VM 事件钩子与数据采集
 
-### 2.1 元信息收集
+### 1.1 目标
 
-- **编译期**：
-  - 在 `LuaCompiler` 输出 `Instruction` 时附带源位置（行列）。方案：为 `Instruction` 增加可选 `meta` 字段或维护并行 `debug_info` 列表。
-  - 函数定义的 `LABEL` 与 `RETURN` 记录所在 Chunk/Function 名称。
-- **运行期**：
-  - VM 捕获异常时，根据 `pc` 和 call stack 读取对应源位置和函数名。
-  - 协程 resume/yield 栈需合并：
-    - 出错协程：从其调用栈 + `LuaCoroutine` 入口函数构造栈层级。
-    - Resume 端：`coroutine.resume` 返回 false 和错误消息（Lua 行为：`false, error_string`).
+- 捕获协程生命周期事件（创建、恢复、挂起、结束）以及它们之间的调用关系。
+- 保持事件结构化、可重放，便于 CLI 与 UI 同时消费。
+- 在不启用可视化器时对现有执行路径影响最小（零或可忽略的性能开销）。
 
-### 2.2 栈回溯格式
+### 1.2 关键改动
 
-目标格式参考 Lua：
-```
-stack traceback:
-	function_name (file.lua:line)
-	...
-```
+| 模块 | 调整内容 |
+| --- | --- |
+| `vm/bytecode_vm.py` | 新增 `CoroutineEvent` 数据类、事件缓冲区、`snapshot_state()`/`drain_events()` 观察接口；为协程调度点埋点。 |
+| `vm/coroutine.py` | 协程实例持有 `coroutine_id`、入口函数标签及最近一次 resume/yield 的参数与返回值。 |
+| `vm/events.py`（新） | 可选：集中声明事件类型与序列化逻辑，便于 CLI/GUI 共享。 |
 
-- 顶层错误字符串示例：
-  - `test.lua:12: attempt to call nil value`
-  - `stack traceback:` 后跟帧列表
-- 协程错误：
-  - `coroutine.resume` 返回 `[False, "test.lua:12: ..."]`
-  - 若 resume 调用在 Lua 脚本中继续抛出，VM 将错误向上传递。
+事件类型初稿：
+- `CoroutineCreated(id, func_label, parent_id, upvalues)`
+- `CoroutineResumed(id, args, scheduler_pc)`
+- `CoroutineYielded(id, values, yield_pc)`
+- `CoroutineCompleted(id, results=None, error=None)`
 
-### 2.3 CLI 调试模式
+每条事件记录当前 VM `pc`、活动栈摘要（函数名、栈深、寄存器窗口）以及触发时间戳，以便时间轴展示。
 
-待错误映射完成后，CLI 可提供：
-- `--trace`：打印每条指令执行日志（可选过滤协程事件）。
-- `--stack`：错误时自动输出完整栈。
-- `--break-on-error`：遇到异常时暂停在可视化器/调试器。
+### 1.3 实施步骤
 
-### 2.4 实现步骤
+1. **事件模型与缓冲区**
+   - 定义事件数据结构和 `BytecodeVM.emit_event(event)` 方法，内部将事件附加到 `self._event_buffer`。
+   - 复用/扩展现有的 `execution_log` 机制，确保老日志消费者仍工作。
 
-1. 扩展 `Instruction` 或维护 `debug_info`，确保代码生成器写入位置信息。
-2. 修改 VM 调度：
-   - `BytecodeVM.run` 捕获 `RuntimeError`，包装为 `LuaRuntimeError`，附带栈帧信息。
-   - `LuaCoroutine.resume` 返回 false + 错误字符串。
-3. 新增格式化工具：`format_traceback(frames)` 生成 Lua 风格文本。
-4. 更新 `run_source`：
-   - 在异常情况下抛出 Python `RuntimeError` 前，利用上述格式化生成易读文本。
-5. 测试：
-   - 编译器：检查 debug 元信息。
-   - VM：模拟错误，验证 traceback 内容。
-   - 协程：确保错误沿 resume 流程返回。
+2. **钩子注入**
+   - 在 `LuaCoroutine.__init__`、`resume`、`yield_from_vm`、`close` 等节点调用 `emit_event`。
+   - 在 `BytecodeVM.run_step`、`call_function`、`return_from_call` 中补充当前协程标识。
+
+3. **状态快照接口**
+   - 提供 `snapshot_state()`，返回：当前协程 ID、所有协程的 `status`、活动栈帧概览、寄存器与 upvalue 视图。
+   - 支持增量获取：`drain_events()` 清空缓冲并返回最新事件列表。
+
+4. **测试与校验**
+   - 单元测试：模拟协程创建→多次 `resume/yield`→完成的序列，断言事件顺序与载荷。
+   - 回归测试：执行非协程脚本，确保事件缓冲为空、性能退化可忽略。
+
+交付物：事件模型文档、API 说明、自动化测试。
 
 ---
 
-此方案将协程可视化与错误调试串联，完成后即可进入 Milestone 3 余下任务的具体实现阶段。
+## 2. 可视化器 UI 升级
+
+### 2.1 目标
+
+- 在图形化与 Headless（日志）模式下直观展示协程状态变化。
+- 允许调试者快速切换查看不同协程的栈帧、寄存器、upvalue 及事件时间线。
+- 将新事件流与现有执行指令时间轴融合，保持 UI 一致性。
+
+### 2.2 工作包
+
+| 组件 | 改动要点 |
+| --- | --- |
+| 状态面板 (`state_panel.py`) | 新增 "Coroutines" 分区，表格列出 `ID`、`status`、最近的 resume/yield 参数；支持点击选中。 |
+| 时间线视图 (`timeline.py`) | 将协程事件插入到指令时间线，`yield`/`resume` 使用不同颜色与图标。 |
+| 栈视图 (`stack_view.py`) | 支持根据选中协程渲染其调用栈，并展示寄存器窗口、upvalue 绑定。 |
+| 事件日志 (`headless_visualizer.py`) | 在 CLI 输出中添加协程事件段落，可通过过滤器隐藏或显示。 |
+
+### 2.3 实施步骤
+
+1. **数据接入层**
+   - 更新可视化器数据源，调用 `vm.drain_events()` 与 `vm.snapshot_state()`。
+   - 对旧版数据格式增加兼容转换，确保无协程脚本仍能显示。
+
+2. **UI 组件扩展**
+   - State Panel：实现协程列表组件，保持与现有栈帧列表一致的交互（键盘/鼠标导航）。
+   - Timeline：为每个事件生成节点，与指令节点共用缩放/滚动逻辑。
+   - Stack View：当用户切换协程时刷新寄存器、upvalue；增加顶部提示当前协程标签。
+
+3. **交互改进**
+   - 添加“自动跟随当前协程”开关：勾选后 UI 自动跳转到 `CoroutineResumed` 事件对应的协程。
+   - 在事件详情面板中显示 resume/yield 参数序列化结果，支持 JSON/表格切换。
+
+4. **测试与文档**
+   - 编写端到端示例脚本，验证协程事件在 GUI 与 Headless 模式下呈现一致。
+   - 更新用户文档与截图，说明如何解读新的协程面板、时间线和日志输出。
+
+交付物：改造后的 UI、新的交互测试、文档更新。
+
+---
+
+## 3. Lua 风格栈回溯与 CLI 调试开关
+
+### 3.1 目标
+
+- 在编译与运行时收集足够的元信息，将 VM 错误映射回 Lua 源文件与行号。
+- 输出与 Lua 5.1+ 兼容的错误消息和 `stack traceback` 文本。
+- 在 CLI 提供 `--trace`、`--stack`、`--break-on-error` 等调试开关，与可视化器联动。
+
+### 3.2 元信息与运行时支撑
+
+1. **编译阶段**
+   - 扩展 `compiler/instruction.py`（或相关结构）以携带 `source_span`（文件、起始/结束行列）。
+   - 构建 `debug_info` 映射：`pc -> (function_label, source_span)`，存储在函数原型/Chunk 中。
+   - 生成函数定义时记录显示名称（函数名、匿名函数 fallback，如 `function <anonymous:line>`）。
+
+2. **运行阶段**
+   - `BytecodeVM` 捕获运行时异常，将当前 `pc` 与调用栈逐帧转换成 `TracebackFrame`：包含函数名、源文件、行号、协程 ID。
+   - 协程错误传播：
+     - 出错协程内抛出 `LuaRuntimeError`，序列化为 Lua 风格字符串。
+     - `coroutine.resume` 在 Python 层返回 `(False, error_string)`；若宿主 Lua 代码继续抛出，则在主协程栈追加 resume 现场。
+
+3. **格式化工具链**
+   - 新增 `debug/traceback.py`：
+     - `format_lua_error(message, frame0)` 生成顶层错误信息（`file.lua:line: message`）。
+     - `format_traceback(frames)` 输出 `stack traceback:` 块。
+   - 提供 API 供 CLI、可视化器及测试共享。
+
+### 3.3 CLI 调试开关路线图
+
+| 开关 | 行为 | 依赖 |
+| --- | --- | --- |
+| `--trace[=<filter>]` | 打印执行指令与事件（可选仅协程事件）；支持输出到文件。 | 事件钩子与元信息（步骤 1、2 完成）。 |
+| `--stack` | 出错时自动打印 Lua 风格 `stack traceback`；可与 `--trace` 叠加。 | Traceback 格式化工具。 |
+| `--break-on-error` | 捕获异常后暂停，等待用户在可视化器或 REPL 中检查状态。 | VM 提供错误上下文、可视化器的协程快照。 |
+
+实现顺序建议：
+1. 在 CLI 层解析参数并将配置注入 VM/Visualizer 会话对象。
+2. `--trace` 先支持基础日志；待协程事件完成后扩展过滤器。
+3. `--stack` 在 Lua 风格栈回溯稳定后启用。
+4. `--break-on-error` 最后实施，与可视化器交互测试同步进行。
+
+### 3.4 验收标准
+
+- 单元测试：
+  - `debug_info` 编解码正确。
+  - `format_traceback` 输出符合 Lua 期望（与示例字符串对比）。
+- 集成测试：
+  - 运行包含协程的脚本触发错误，验证 `coroutine.resume` 返回值与 CLI 输出。
+  - CLI 启用各开关组合时行为正确、互不冲突。
+- 文档与示例：提供错误输出示例、CLI 使用说明、常见问题排查指南。
+
+---
+
+## 4. 里程碑与依赖关系
+
+1. **Milestone A：VM 事件钩子**（~1 sprint）
+   - 完成 §1 的事件模型、缓冲区、基础测试。
+   - 暂以简单日志驱动可视化器，验证事件流完整性。
+
+2. **Milestone B：可视化器 UI**（~1 sprint）
+   - 在事件流稳定后迭代 UI，交付新的协程面板与时间线。
+   - 更新文档与演示脚本。
+
+3. **Milestone C：Lua 栈回溯 + CLI 开关**（~1–1.5 sprint）
+   - 编译期元信息 → 运行期错误映射 → CLI 调试开关依次完成。
+   - 与可视化器协同测试，确保错误触发后能正确暂停并展示协程状态。
+
+完成以上步骤后，协程调试体验将覆盖事件采集、可视化、错误诊断全链路，可为后续高级调试功能（断点、性能分析）提供坚实基础。


### PR DESCRIPTION
## Summary
- extend coroutine event dataclasses to carry scheduler/coroutine pc data, call stacks, and captured upvalues
- update the VM coroutine runtime to record stack-aware snapshots and emit richer events for resume, yield, and completion paths
- surface the additional metadata in both visualizers and the CLI while expanding stdlib coroutine tests to cover the new telemetry

## Testing
- pytest


------
https://chatgpt.com/codex/tasks/task_e_68d37bce3b78832c8cb80968d5ad0a8e