### PR TITLE
feat: upgrade visualizer for coroutine timeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,10 +115,12 @@ Haifa Python 提供了一个教学友好的编译器与虚拟机实验平台：
       "PRINT max"
   ]
 
-  bytecode = ASTCompiler().compile(parse(script))
-  vm = BytecodeVM(bytecode)
-  VMVisualizer(vm).run()
-  ```
+bytecode = ASTCompiler().compile(parse(script))
+vm = BytecodeVM(bytecode)
+VMVisualizer(vm).run()
+```
+
+> 提示：GUI 可视化器会展示协程列表、事件时间线与参数详情；示例脚本可参考 `examples/coroutines.lua`，更多说明见 `docs/guide.md` 第 6 节。
   在 GUI 内使用 `SPACE` 单步或 `p`/`q` 控制，以查看 `CALL max2` 时调用栈的变化。支持 `/` 搜索指令、寄存器变更高亮，以及 `L` 导出执行轨迹（JSONL）。
 
 ### jq 命令行示例

--- a/compiler/vm_events.py
+++ b/compiler/vm_events.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from typing import Any, List, Mapping, Sequence
+from typing import Any, List, Mapping, Optional, Sequence
 
 
 @dataclass(frozen=True)
@@ -57,6 +57,12 @@ class CoroutineSnapshot:
     status: str
     last_yield: List[Any]
     last_error: str | None
+    function_name: Optional[str] = None
+    last_resume_args: List[Any] = field(default_factory=list)
+    registers: Optional[Mapping[str, Any]] = None
+    upvalues: Optional[Sequence[Any]] = None
+    call_stack: Sequence[TraceFrame] = field(default_factory=list)
+    current_pc: Optional[int] = None
 
 
 @dataclass
@@ -67,6 +73,9 @@ class VMStateSnapshot:
     stack: Sequence[Any]
     call_stack: Sequence[TraceFrame]
     coroutines: Sequence[CoroutineSnapshot] = field(default_factory=list)
+    upvalues: Sequence[Any] = field(default_factory=list)
+    emit_stack: Sequence[Any] = field(default_factory=list)
+    output: Sequence[Any] = field(default_factory=list)
 
 
 __all__ = [

--- a/compiler/vm_visualizer.py
+++ b/compiler/vm_visualizer.py
@@ -1,7 +1,7 @@
 import datetime
 import json
 import sys
-from typing import Any, Dict, List, Set, Tuple
+from typing import Any, Dict, List, Mapping, Optional, Set, Tuple
 
 import pygame
 
@@ -13,7 +13,9 @@ try:
         CoroutineCreated,
         CoroutineEvent,
         CoroutineResumed,
+        CoroutineSnapshot,
         CoroutineYielded,
+        VMStateSnapshot,
     )
 except Exception:  # fallback when run as top-level script
     from compiler.bytecode import Instruction  # type: ignore
@@ -23,7 +25,9 @@ except Exception:  # fallback when run as top-level script
         CoroutineCreated,
         CoroutineEvent,
         CoroutineResumed,
+        CoroutineSnapshot,
         CoroutineYielded,
+        VMStateSnapshot,
     )
 
 # Constants
@@ -35,6 +39,8 @@ HIGHLIGHT_COLOR = (255, 255, 0)
 PC_COLOR = (200, 255, 200)
 CHANGE_COLOR = (255, 220, 200)
 SEARCH_HIGHLIGHT_COLOR = (255, 240, 170)
+CURRENT_COROUTINE_COLOR = (200, 220, 255)
+TIMELINE_COROUTINE_COLOR = (225, 240, 255)
 FONT_SIZE = 18
 LINE_HEIGHT = 22
 MARGIN = 20
@@ -53,9 +59,18 @@ class VMVisualizer:
         self.prev_registers: Dict[str, Any] = {}
         self.search_mode = False
         self.search_query = ""
-        self.message = "Press P to run, SPACE to step, / to search."
+        self.message = "Press P to run, SPACE to step, / to search. Use arrows to navigate."
         self.trace_log: List[Dict[str, Any]] = []
         self.event_log: List[str] = []
+        self.timeline_events: List[Dict[str, Any]] = []
+        self.timeline_start: Optional[float] = None
+        self.selected_event_index = -1
+        self.selected_coroutine_id: Optional[int] = None
+        self.coroutine_selection_index = -1
+        self.auto_follow_coroutine = True
+        self._latest_coroutines: List[CoroutineSnapshot] = []
+        self._coroutine_index_map: Dict[int, int] = {}
+        self._latest_snapshot: Optional[VMStateSnapshot] = None
         self._vm_cls = type(vm)
         # Keep a frozen copy of instructions for resetting
         self._instructions = list(vm.instructions)
@@ -102,10 +117,48 @@ class VMVisualizer:
 
     def _consume_events(self) -> None:
         events = self.vm.drain_events()
+        if not events:
+            return
+
         for event in events:
-            self.event_log.append(self._format_event(event))
-        if len(self.event_log) > 200:
-            self.event_log = self.event_log[-200:]
+            label = self._format_event(event)
+            timestamp = getattr(event, "timestamp", None)
+            entry = {
+                "event": event,
+                "label": label,
+                "timestamp": timestamp,
+                "coroutine_id": getattr(event, "coroutine_id", None),
+                "type": type(event).__name__,
+            }
+            self.timeline_events.append(entry)
+            self.event_log.append(label)
+            if isinstance(event, CoroutineResumed) and self.auto_follow_coroutine:
+                self.selected_coroutine_id = event.coroutine_id
+            elif (
+                isinstance(event, CoroutineCreated)
+                and self.selected_coroutine_id is None
+            ):
+                self.selected_coroutine_id = event.coroutine_id
+
+        if self.timeline_events and self.timeline_start is None:
+            first_ts = self.timeline_events[0].get("timestamp")
+            if first_ts is not None:
+                self.timeline_start = first_ts
+
+        if self.timeline_events:
+            self.selected_event_index = len(self.timeline_events) - 1
+
+        max_events = 400
+        if len(self.timeline_events) > max_events:
+            self.timeline_events = self.timeline_events[-max_events:]
+            self.event_log = self.event_log[-max_events:]
+            if self.selected_event_index >= 0:
+                self.selected_event_index = min(
+                    len(self.timeline_events) - 1,
+                    self.selected_event_index,
+                )
+            first_ts = self.timeline_events[0].get("timestamp")
+            self.timeline_start = first_ts if first_ts is not None else self.timeline_start
 
     def _format_event(self, event: CoroutineEvent) -> str:
         if isinstance(event, CoroutineCreated):
@@ -122,34 +175,200 @@ class VMVisualizer:
             return f"coroutine #{event.coroutine_id} done values={self._format_value(event.values)}"
         return str(event)
 
+    def _compact_value(self, value: Any, limit: int = 36) -> str:
+        formatted = self._format_value(value)
+        if len(formatted) > limit:
+            return formatted[: limit - 3] + "..."
+        return formatted
+
+    def _format_timeline_entry(self, entry: Dict[str, Any]) -> str:
+        label = entry.get("label", "<event>")
+        timestamp = entry.get("timestamp")
+        if timestamp is not None:
+            if self.timeline_start is None:
+                self.timeline_start = timestamp
+            delta = timestamp - (self.timeline_start or timestamp)
+            return f"+{delta:6.2f}s {label}"
+        return f"   --.-s {label}"
+
+    def _format_event_detail(self, entry: Dict[str, Any]) -> List[str]:
+        event = entry["event"]
+        lines = [f"type: {entry.get('type', '<unknown>')}"]
+        coroutine_id = getattr(event, "coroutine_id", None)
+        if coroutine_id is not None:
+            lines.append(f"coroutine: #{coroutine_id}")
+        timestamp = entry.get("timestamp")
+        if timestamp is not None:
+            iso = datetime.datetime.fromtimestamp(timestamp).isoformat(timespec="milliseconds")
+            lines.append(f"time: {iso}")
+        if isinstance(event, CoroutineCreated):
+            if event.parent_id is not None:
+                lines.append(f"parent: #{event.parent_id}")
+            if event.function_name:
+                lines.append(f"function: {event.function_name}")
+            if event.args:
+                lines.append(f"args: {self._format_value(list(event.args))}")
+        elif isinstance(event, CoroutineResumed):
+            lines.append(f"args: {self._format_value(list(event.args))}")
+        elif isinstance(event, CoroutineYielded):
+            lines.append(f"values: {self._format_value(list(event.values))}")
+            lines.append(f"pc: {event.pc}")
+        elif isinstance(event, CoroutineCompleted):
+            if event.error:
+                lines.append(f"error: {event.error}")
+            else:
+                lines.append(f"values: {self._format_value(list(event.values))}")
+        return lines
+
+    def _move_coroutine_selection(self, delta: int) -> None:
+        if not self._latest_coroutines:
+            return
+        index = self.coroutine_selection_index
+        if index < 0:
+            index = 0 if delta >= 0 else len(self._latest_coroutines) - 1
+        new_index = max(0, min(len(self._latest_coroutines) - 1, index + delta))
+        if new_index == self.coroutine_selection_index:
+            return
+        self.coroutine_selection_index = new_index
+        snapshot = self._latest_coroutines[new_index]
+        self.selected_coroutine_id = snapshot.coroutine_id
+        self.message = f"Selected coroutine #{snapshot.coroutine_id}"
+
+    def _move_timeline_selection(self, delta: int) -> None:
+        if not self.timeline_events:
+            return
+        index = self.selected_event_index
+        if index < 0:
+            index = len(self.timeline_events) - 1
+        new_index = max(0, min(len(self.timeline_events) - 1, index + delta))
+        if new_index == self.selected_event_index:
+            return
+        self.selected_event_index = new_index
+        entry = self.timeline_events[new_index]
+        label = entry.get("label", "<event>")
+        coroutine_id = entry.get("coroutine_id")
+        if coroutine_id in self._coroutine_index_map:
+            self.selected_coroutine_id = coroutine_id
+            self.coroutine_selection_index = self._coroutine_index_map[coroutine_id]
+        self.message = f"Timeline → {label}"
+
     def _prepare_data(self):
         instructions_data, highlight_idx, match_highlights = self._prepare_instruction_display()
 
-        registers_data, changed_indices = self._prepare_register_display()
-
         snapshot = self.vm.snapshot_state()
-        stack_data = [
-            f"{frame.function_name} @ {frame.file}:{frame.line} (pc={frame.pc})"
-            for frame in snapshot.call_stack
-        ]
-
-        coroutine_data: List[str] = []
-        current_index = -1
-        for idx, coro in enumerate(snapshot.coroutines):
-            status = coro.status
-            yield_display = self._format_value(coro.last_yield)
-            line = f"#{coro.coroutine_id} {status:<10} yield={yield_display}"
-            if coro.last_error:
-                line += f" error={coro.last_error}"
-            coroutine_data.append(line)
-            if snapshot.current_coroutine == coro.coroutine_id:
-                current_index = idx
+        self._latest_snapshot = snapshot
+        registers_data, changed_indices = self._prepare_register_display(snapshot.registers)
 
         self._consume_events()
 
-        output_data = [self._format_value(item) for item in self.vm.output]
+        coroutine_snapshots = list(snapshot.coroutines)
+        self._latest_coroutines = coroutine_snapshots
+        self._coroutine_index_map = {
+            coro.coroutine_id: idx for idx, coro in enumerate(coroutine_snapshots)
+        }
 
-        emit_stack_data = [str(s) for s in self.vm.emit_stack]
+        current_index = self._coroutine_index_map.get(snapshot.current_coroutine, -1)
+        if (
+            self.selected_coroutine_id is None
+            or self.selected_coroutine_id not in self._coroutine_index_map
+        ):
+            if snapshot.current_coroutine in self._coroutine_index_map:
+                self.selected_coroutine_id = snapshot.current_coroutine
+            elif coroutine_snapshots:
+                self.selected_coroutine_id = coroutine_snapshots[0].coroutine_id
+            else:
+                self.selected_coroutine_id = None
+
+        selected_index = self._coroutine_index_map.get(self.selected_coroutine_id, -1)
+        self.coroutine_selection_index = selected_index
+
+        coroutine_data: List[str] = []
+        for idx, coro in enumerate(coroutine_snapshots):
+            resume_display = self._compact_value(coro.last_resume_args)
+            yield_display = self._compact_value(coro.last_yield)
+            name_part = f" fn={coro.function_name}" if coro.function_name else ""
+            pc_part = f" pc={coro.current_pc}" if coro.current_pc is not None else ""
+            line = (
+                f"#{coro.coroutine_id:02d} {coro.status:<10} "
+                f"resume={resume_display} yield={yield_display}{pc_part}{name_part}"
+            )
+            if coro.last_error:
+                line += f" error={coro.last_error}"
+            coroutine_data.append(line)
+
+        selected_snapshot: Optional[CoroutineSnapshot]
+        if selected_index != -1:
+            selected_snapshot = coroutine_snapshots[selected_index]
+        else:
+            selected_snapshot = None
+
+        if selected_snapshot and selected_snapshot.registers is not None:
+            coroutine_registers_data = [
+                f"{name}: {self._format_value(value)}"
+                for name, value in sorted(selected_snapshot.registers.items())
+            ]
+            if not coroutine_registers_data:
+                coroutine_registers_data = ["<empty>"]
+        elif selected_snapshot:
+            coroutine_registers_data = ["<register snapshot unavailable>"]
+        else:
+            coroutine_registers_data = ["<no coroutine selected>"]
+
+        if selected_snapshot and selected_snapshot.upvalues is not None:
+            coroutine_upvalues_data = [
+                f"{idx}: {self._format_value(value)}"
+                for idx, value in enumerate(selected_snapshot.upvalues)
+            ]
+            if not coroutine_upvalues_data:
+                coroutine_upvalues_data = ["<empty>"]
+        elif selected_snapshot:
+            coroutine_upvalues_data = ["<upvalue snapshot unavailable>"]
+        else:
+            coroutine_upvalues_data = [
+                f"{idx}: {self._format_value(value)}"
+                for idx, value in enumerate(snapshot.upvalues)
+            ] or ["<no upvalues>"]
+
+        if selected_snapshot and selected_snapshot.call_stack:
+            coroutine_stack_data = [
+                f"{frame.function_name} @ {frame.file}:{frame.line} (pc={frame.pc})"
+                for frame in selected_snapshot.call_stack
+            ]
+        else:
+            coroutine_stack_data = [
+                f"{frame.function_name} @ {frame.file}:{frame.line} (pc={frame.pc})"
+                for frame in snapshot.call_stack
+            ]
+            if not coroutine_stack_data:
+                coroutine_stack_data = ["<no call stack>"]
+
+        emit_stack_data = [self._format_value(item) for item in snapshot.emit_stack]
+        if not emit_stack_data:
+            emit_stack_data = ["<empty>"]
+
+        output_data = [self._format_value(item) for item in snapshot.output]
+        if not output_data:
+            output_data = ["<empty>"]
+
+        if self.selected_event_index >= len(self.timeline_events):
+            self.selected_event_index = len(self.timeline_events) - 1
+        if self.selected_event_index < 0 and self.timeline_events:
+            self.selected_event_index = len(self.timeline_events) - 1
+
+        timeline_data = [self._format_timeline_entry(entry) for entry in self.timeline_events]
+        timeline_highlight = self.selected_event_index
+        timeline_coroutine_indices = {
+            idx
+            for idx, entry in enumerate(self.timeline_events)
+            if entry.get("coroutine_id") == self.selected_coroutine_id
+        }
+
+        if 0 <= self.selected_event_index < len(self.timeline_events):
+            event_detail_lines = self._format_event_detail(
+                self.timeline_events[self.selected_event_index]
+            )
+        else:
+            event_detail_lines = ["<no event selected>"]
 
         return (
             instructions_data,
@@ -157,12 +376,18 @@ class VMVisualizer:
             match_highlights,
             registers_data,
             changed_indices,
-            stack_data,
-            output_data,
+            coroutine_registers_data,
+            coroutine_upvalues_data,
+            coroutine_stack_data,
             emit_stack_data,
+            output_data,
             coroutine_data,
+            selected_index,
             current_index,
-            list(self.event_log[-30:]),
+            timeline_data,
+            timeline_highlight,
+            timeline_coroutine_indices,
+            event_detail_lines,
         )
 
     def _prepare_instruction_display(self) -> Tuple[List[str], int, Set[int]]:
@@ -201,10 +426,10 @@ class VMVisualizer:
 
         return instructions_data, highlight_idx, match_highlights
 
-    def _prepare_register_display(self) -> Tuple[List[str], Set[int]]:
+    def _prepare_register_display(self, registers: Mapping[str, Any]) -> Tuple[List[str], Set[int]]:
         registers_data: List[str] = []
         changed_indices: Set[int] = set()
-        sorted_items = sorted(self.vm.registers.items())
+        sorted_items = sorted(registers.items())
         for idx, (reg, val) in enumerate(sorted_items):
             display = self._format_value(val)
             registers_data.append(f"{reg}: {display}")
@@ -222,12 +447,18 @@ class VMVisualizer:
             match_highlights,
             registers_data,
             changed_register_indices,
-            stack_data,
-            output_data,
+            coroutine_registers_data,
+            coroutine_upvalues_data,
+            coroutine_stack_data,
             emit_stack_data,
+            output_data,
             coroutine_data,
-            coroutine_highlight,
-            event_log,
+            coroutine_selected_index,
+            coroutine_current_index,
+            timeline_data,
+            timeline_highlight,
+            timeline_secondary,
+            event_detail_lines,
         ) = self._prepare_data()
 
         # Instructions
@@ -243,35 +474,69 @@ class VMVisualizer:
             secondary_color=HIGHLIGHT_COLOR,
         )
 
-        # Registers
+        # VM Registers
         self._draw_section(
-            "Registers",
+            "VM Registers",
             registers_data,
             640,
             MARGIN,
             450,
-            400,
+            210,
             secondary_highlights=changed_register_indices,
             secondary_color=CHANGE_COLOR,
         )
 
-        # Call Stack
-        self._draw_section("Call Stack", stack_data, 640, 440, 450, 200)
+        # Coroutine-specific panels
+        center_x = 640
+        center_width = 450
+        y = MARGIN + 210 + 20
+        self._draw_section(
+            "Coroutine Registers",
+            coroutine_registers_data,
+            center_x,
+            y,
+            center_width,
+            150,
+        )
 
-        # Emit Stack
-        emit_y = 660
-        emit_height = 120
-        self._draw_section("Emit Stack", emit_stack_data, 640, emit_y, 450, emit_height)
+        y += 150 + 20
+        self._draw_section(
+            "Coroutine Upvalues",
+            coroutine_upvalues_data,
+            center_x,
+            y,
+            center_width,
+            110,
+        )
 
-        # Output below emit stack
-        output_y = emit_y + emit_height + 20
-        output_height = SCREEN_HEIGHT - output_y - MARGIN
-        self._draw_section("Output", output_data, 640, output_y, 450, output_height)
+        y += 110 + 20
+        self._draw_section(
+            "Coroutine Stack",
+            coroutine_stack_data,
+            center_x,
+            y,
+            center_width,
+            160,
+        )
+
+        y += 160 + 20
+        self._draw_section("Emit Stack", emit_stack_data, center_x, y, center_width, 80)
+
+        y += 80 + 20
+        output_height = max(60, SCREEN_HEIGHT - y - MARGIN)
+        self._draw_section("Output", output_data, center_x, y, center_width, output_height)
 
         # Coroutines panel on right
         right_x = 1110
         right_width = SCREEN_WIDTH - right_x - MARGIN
-        coroutine_height = 240
+        coroutine_height = 260
+        coroutine_secondary = set()
+        if (
+            coroutine_current_index is not None
+            and coroutine_current_index >= 0
+            and coroutine_current_index != coroutine_selected_index
+        ):
+            coroutine_secondary.add(coroutine_current_index)
         self._draw_section(
             "Coroutines",
             coroutine_data or ["<none>"],
@@ -279,24 +544,44 @@ class VMVisualizer:
             MARGIN,
             right_width,
             coroutine_height,
-            highlight_index=coroutine_highlight,
+            highlight_index=coroutine_selected_index,
+            secondary_highlights=coroutine_secondary,
+            secondary_color=CURRENT_COROUTINE_COLOR,
         )
 
-        # Coroutine events below
+        # Timeline and event detail panels
         events_y = MARGIN + coroutine_height + 20
-        events_height = SCREEN_HEIGHT - events_y - MARGIN
+        timeline_height = 300
         self._draw_section(
-            "Coroutine Events",
-            list(reversed(event_log)) or ["<no events>"],
+            "Timeline",
+            timeline_data or ["<no events>"],
             right_x,
             events_y,
             right_width,
-            events_height,
+            timeline_height,
+            highlight_index=timeline_highlight,
+            secondary_highlights=timeline_secondary,
+            secondary_color=TIMELINE_COROUTINE_COLOR,
+        )
+
+        detail_y = events_y + timeline_height + 20
+        detail_height = max(120, SCREEN_HEIGHT - detail_y - MARGIN)
+        self._draw_section(
+            "Event Detail",
+            event_detail_lines,
+            right_x,
+            detail_y,
+            right_width,
+            detail_height,
         )
 
         # Status/Help
         status_text = "PAUSED" if self.paused else "RUNNING"
-        help_text = "[SPACE] to step, [P] to toggle pause/run, [Q] to quit"
+        follow_text = "ON" if self.auto_follow_coroutine else "OFF"
+        help_text = (
+            "[SPACE] step [P] run/pause [Q] quit [F] follow "
+            "[ARROWS] navigate [/] search [L] export"
+        )
         msg_y = SCREEN_HEIGHT - MARGIN - 40
         if self.search_mode or self.search_query:
             cursor = "_" if self.search_mode else ""
@@ -310,12 +595,18 @@ class VMVisualizer:
         if self.message:
             self._draw_text(f"Msg: {self.message}", MARGIN, msg_y, color=(100, 100, 100))
             msg_y += LINE_HEIGHT
-        self._draw_text(f"Status: {status_text}", MARGIN, msg_y, color=(100, 100, 100))
-        self._draw_text(help_text + " | [/ ] search, [L] export trace", MARGIN + 220, msg_y, color=(100, 100, 100))
+        self._draw_text(
+            f"Status: {status_text} | Auto-follow: {follow_text}",
+            MARGIN,
+            msg_y,
+            color=(100, 100, 100),
+        )
+        self._draw_text(help_text, MARGIN + 320, msg_y, color=(100, 100, 100))
 
         pygame.display.flip()
         # Update reference for diff detection after drawing
-        self.prev_registers = dict(self.vm.registers)
+        if self._latest_snapshot is not None:
+            self.prev_registers = dict(self._latest_snapshot.registers)
 
     def _handle_events(self):
         for event in pygame.event.get():
@@ -339,6 +630,21 @@ class VMVisualizer:
                     self.paused = not self.paused
                     self.auto_run = not self.paused
                     self.message = "Running..." if not self.paused else "Paused."
+                elif event.key == pygame.K_f:
+                    self.auto_follow_coroutine = not self.auto_follow_coroutine
+                    self.message = (
+                        "Auto-follow enabled."
+                        if self.auto_follow_coroutine
+                        else "Auto-follow disabled."
+                    )
+                elif event.key == pygame.K_UP:
+                    self._move_coroutine_selection(-1)
+                elif event.key == pygame.K_DOWN:
+                    self._move_coroutine_selection(1)
+                elif event.key == pygame.K_LEFT:
+                    self._move_timeline_selection(-1)
+                elif event.key == pygame.K_RIGHT:
+                    self._move_timeline_selection(1)
                 elif event.key == pygame.K_l:
                     self._export_trace()
                 elif event.key == pygame.K_r:
@@ -424,4 +730,13 @@ class VMVisualizer:
         self.auto_run = False
         self.prev_registers = {}
         self.trace_log.clear()
+        self.timeline_events.clear()
+        self.event_log.clear()
+        self.timeline_start = None
+        self.selected_event_index = -1
+        self.selected_coroutine_id = None
+        self.coroutine_selection_index = -1
+        self._latest_coroutines = []
+        self._coroutine_index_map = {}
+        self._latest_snapshot = None
         self.message = "VM reset."

--- a/docs/guide.md
+++ b/docs/guide.md
@@ -161,10 +161,24 @@ vm = BytecodeVM(bytecode)
 VMVisualizer(vm).run()
 ```
 
-### 6.3 可视化器快捷键
-- GUI 版：`P` 运行/暂停、`SPACE` 单步、`/` 进入指令搜索（回车确认、ESC 取消）、`L` 导出执行轨迹（JSONL）、`R` 重置、`Q` 退出。
-- GUI 会高亮最近变更的寄存器，并在搜索期间标记匹配指令。
-- 导出轨迹文件位于当前目录，命名为 `vm_trace_YYYYMMDD_HHMMSS.jsonl`。
+### 6.3 可视化器面板与快捷键
+GUI 版可视化器拆分为三个区域：
+
+- **左侧指令区**：展示指令列表，可通过 `/` 搜索并定位到当前 PC。
+- **中部状态区**：包含全局寄存器、选中协程的寄存器/Upvalue/调用栈，以及 Emit Stack、Output 等调试信息。
+- **右侧协程与时间线区**：上方列出当前协程列表，下方时间线会记录 `create/resume/yield/complete` 事件，并在最底部展示事件详情。
+
+常用快捷键：
+
+- `P` 运行/暂停自动执行。
+- `SPACE` 单步执行。
+- `↑` / `↓` 切换选中的协程，面板随之刷新寄存器与栈信息。
+- `←` / `→` 在时间线中切换事件，右侧详情会显示参数与 PC。
+- `F` 开关“自动跟随当前协程”，开启后 `resume` 会自动选中对应协程。
+- `/` 进入指令搜索（回车确认、ESC 取消）。
+- `L` 导出执行轨迹（JSONL），`R` 重置虚拟机，`Q` 退出。
+
+GUI 会高亮最近变更的寄存器，时间线还会对当前选中的协程事件进行浅色标记。导出的轨迹文件位于当前目录，命名为 `vm_trace_YYYYMMDD_HHMMSS.jsonl`。
 
 ## 7. 可视化执行流程
 使用 `--visualize` 结合内建 VM 可视化器，查看字节码执行：
@@ -184,8 +198,32 @@ Headless 模式基于 `curses` 渲染，常用按键：
 - `SPACE` / `p`：开始/暂停自动执行
 - `n` / 右方向键：单步执行
 - `r`：重置并回到初始状态
+- `e`：切换协程事件列表的显示/隐藏（右栏仍会保留最近一条事件详情）
 - `q`：退出
-- Headless 默认逐步打印寄存器/输出变化；如需导出轨迹，可在 GUI 模式运行后使用 `L` 键生成文件。
+- Headless 会同步展示当前协程寄存器、Upvalue 与最近事件详情；如需导出轨迹，可在 GUI 模式运行后使用 `L` 键生成文件。
+
+### 6.4 协程事件示例
+
+仓库新增示例脚本 `examples/coroutines.lua`，模拟两个协程交替 `yield` 的过程，可直接加载到可视化器中：
+
+```python
+from pathlib import Path
+
+from compiler.bytecode_vm import BytecodeVM
+from compiler.vm_visualizer import VMVisualizer
+from haifa_lua.runtime import compile_source
+
+source = Path("examples/coroutines.lua").read_text(encoding="utf-8")
+instructions = list(compile_source(source, source_name="coroutines.lua"))
+vm = BytecodeVM(instructions)
+VMVisualizer(vm).run()
+```
+
+若处于终端环境，可用 `pylua` 的 `--trace coroutine` 选项打印同样的事件序列：
+
+```bash
+python -m haifa_lua.cli examples/coroutines.lua --trace coroutine
+```
 
 ## 8. 常见问题
 

--- a/examples/coroutines.lua
+++ b/examples/coroutines.lua
@@ -1,0 +1,20 @@
+function ticker(label, count)
+    for i = 1, count do
+        local resume_value = coroutine.yield(label .. " tick", i)
+        if resume_value then
+            label = label .. "+" .. tostring(resume_value)
+        end
+    end
+    return label .. " done", count
+end
+
+local blue = coroutine.create(ticker)
+local green = coroutine.create(ticker)
+
+print(coroutine.resume(blue, "blue", 2))
+print(coroutine.resume(green, "green", 3))
+print(coroutine.resume(blue, "B"))
+print(coroutine.resume(blue))
+print(coroutine.resume(green, "G"))
+print(coroutine.resume(green))
+print(coroutine.resume(green))


### PR DESCRIPTION
## Summary
- enrich VM snapshots with coroutine registers, upvalues and expose new coroutine example script
- overhaul GUI visualizer with coroutine panel, event timeline, auto-follow controls and detailed event view
- refresh headless visualizer shortcuts, documentation and tests to cover the new coroutine metadata

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d3b92eb5bc832c8e27b8040d260be1