### PR TITLE
Fix coroutine examples for limited Lua subset

### DIFF
--- a/examples/coroutine_basic.lua
+++ b/examples/coroutine_basic.lua
@@ -7,31 +7,31 @@ print("=== 协程基础示例 ===")
 function simple_coroutine()
     print("协程开始执行")
     coroutine.yield("第一次暂停")
+
     print("协程恢复执行")
-    coroutine.yield("第二次暂停") 
+    coroutine.yield("第二次暂停")
+
     print("协程即将结束")
     return "协程执行完毕"
 end
 
 -- 创建协程
 local co = coroutine.create(simple_coroutine)
+print("协程已创建，等待调度")
 
-print("协程状态:", coroutine.status(co))
+local function resume_and_report(co, ...)
+    print("返回值:", coroutine.resume(co, ...))
+end
 
 -- 第一次恢复协程
 print("--- 第一次调用 resume ---")
-local success, result = coroutine.resume(co)
-print("返回值:", success, result)
-print("协程状态:", coroutine.status(co))
+resume_and_report(co)
 
 -- 第二次恢复协程
 print("--- 第二次调用 resume ---")
-success, result = coroutine.resume(co)
-print("返回值:", success, result)
-print("协程状态:", coroutine.status(co))
+resume_and_report(co)
 
 -- 第三次恢复协程
 print("--- 第三次调用 resume ---")
-success, result = coroutine.resume(co)
-print("返回值:", success, result)
-print("协程状态:", coroutine.status(co))
+resume_and_report(co)
+

--- a/examples/coroutine_data_exchange.lua
+++ b/examples/coroutine_data_exchange.lua
@@ -4,33 +4,27 @@
 print("=== 协程数据传递示例 ===")
 
 function data_processor(initial_data)
-    print("协程接收到初始数据:", initial_data)
-    
-    -- 处理数据并返回结果，同时接收新数据
-    local received = coroutine.yield("处理结果: " .. initial_data * 2)
-    print("协程接收到新数据:", received)
-    
-    -- 再次处理并返回
-    received = coroutine.yield("累加结果: " .. (initial_data * 2 + received))
-    print("协程接收到最终数据:", received)
-    
-    return "最终处理完成: " .. (initial_data * 2 + received * 3)
+    local received = coroutine.yield("处理结果", initial_data * 2)
+    received = coroutine.yield("累加结果", initial_data * 2 + received)
+    return "最终处理完成", initial_data * 2 + received * 3
 end
 
 -- 创建协程
 local co = coroutine.create(data_processor)
 
+local function resume_and_show(co, ...)
+    print("主程序接收到:", coroutine.resume(co, ...))
+end
+
 -- 启动协程并传入初始数据
 print("--- 启动协程，传入数据: 10 ---")
-local success, result = coroutine.resume(co, 10)
-print("主程序接收到:", result)
+resume_and_show(co, 10)
 
 -- 传入新数据继续协程
 print("--- 传入新数据: 5 ---")
-success, result = coroutine.resume(co, 5)
-print("主程序接收到:", result)
+resume_and_show(co, 5)
 
 -- 传入最后的数据
 print("--- 传入最终数据: 3 ---")
-success, result = coroutine.resume(co, 3)
-print("主程序接收到:", result)
+resume_and_show(co, 3)
+

--- a/examples/coroutine_producer_consumer.lua
+++ b/examples/coroutine_producer_consumer.lua
@@ -3,48 +3,57 @@
 
 print("=== 协程生产者-消费者示例 ===")
 
+function get_item(index)
+    if index == 1 then
+        return "苹果"
+    end
+    if index == 2 then
+        return "香蕉"
+    end
+    if index == 3 then
+        return "橙子"
+    end
+    if index == 4 then
+        return "葡萄"
+    end
+    if index == 5 then
+        return "草莓"
+    end
+    return nil
+end
+
 -- 生产者协程
 function producer()
-    local items = {"苹果", "香蕉", "橙子", "葡萄", "草莓"}
-    
-    for i = 1, #items do
-        print("生产者: 正在生产", items[i])
-        coroutine.yield(items[i])  -- 产出物品
-        print("生产者: 继续生产下一个物品")
+    local index = 0
+
+    while index < 5 do
+        index = index + 1
+        local item = get_item(index)
+        coroutine.yield("物品", item)
     end
-    
-    print("生产者: 所有物品生产完毕")
-    return nil  -- 生产结束
+
+    return "完成"
 end
 
 -- 消费者函数（主程序扮演消费者）
 function consumer()
     local co = coroutine.create(producer)
     local item_count = 0
-    
-    while true do
-        local success, item = coroutine.resume(co)
-        
-        if not success then
-            print("消费者: 协程执行出错")
-            break
-        end
-        
-        if item == nil then
-            print("消费者: 没有更多物品了")
-            break
-        end
-        
+
+    while item_count < 5 do
         item_count = item_count + 1
-        print("消费者: 接收到第" .. item_count .. "个物品:", item)
+        print("消费者: 请求第", item_count, "个物品")
+        print("返回值:", coroutine.resume(co))
+        local item = get_item(item_count)
         print("消费者: 正在消费", item)
         print("消费者: 请求下一个物品...")
         print("---")
     end
-    
+
+    print("协程最终返回:", coroutine.resume(co))
     print("消费者: 总共消费了", item_count, "个物品")
-    print("协程最终状态:", coroutine.status(co))
 end
 
 -- 开始消费流程
 consumer()
+


### PR DESCRIPTION
## Summary
- rewrite the coroutine basic example to report resume results without multi-assignment or coroutine.status
- adjust the data exchange example to yield label/value pairs and print resume outputs directly
- rework the producer-consumer example to avoid tables and elseif while showing each yielded item via resume output

## Testing
- python -m haifa_lua.cli examples/coroutine_basic.lua --print-output
- python -m haifa_lua.cli examples/coroutine_data_exchange.lua --print-output
- python -m haifa_lua.cli examples/coroutine_producer_consumer.lua --print-output

------
https://chatgpt.com/codex/tasks/task_e_68d3bf648564832c961906deddfd5349