### PR TITLE
Implement metatable and object semantics for Lua frontend

### DIFF
--- a/compiler/bytecode_vm.py
+++ b/compiler/bytecode_vm.py
@@ -345,20 +345,55 @@ class BytecodeVM:
         self.registers[args[0]] = value
 
     def _op_ADD(self, args):
-        self.registers[args[0]] = self.val(args[1]) + self.val(args[2])
+        dst, left_reg, right_reg = args
+        left = self.val(left_reg)
+        right = self.val(right_reg)
+        invoked, result = self._invoke_binary_metamethod("__add", left, right)
+        if invoked:
+            self.registers[dst] = result
+        else:
+            self.registers[dst] = left + right
 
     def _op_SUB(self, args):
-        self.registers[args[0]] = self.val(args[1]) - self.val(args[2])
+        dst, left_reg, right_reg = args
+        left = self.val(left_reg)
+        right = self.val(right_reg)
+        invoked, result = self._invoke_binary_metamethod("__sub", left, right)
+        if invoked:
+            self.registers[dst] = result
+        else:
+            self.registers[dst] = left - right
 
     def _op_MUL(self, args):
-        self.registers[args[0]] = self.val(args[1]) * self.val(args[2])
+        dst, left_reg, right_reg = args
+        left = self.val(left_reg)
+        right = self.val(right_reg)
+        invoked, result = self._invoke_binary_metamethod("__mul", left, right)
+        if invoked:
+            self.registers[dst] = result
+        else:
+            self.registers[dst] = left * right
 
     def _op_DIV(self, args):
-        # 整数整除，保持兼容
-        self.registers[args[0]] = self.val(args[1]) // self.val(args[2])
+        dst, left_reg, right_reg = args
+        left = self.val(left_reg)
+        right = self.val(right_reg)
+        invoked, result = self._invoke_binary_metamethod("__div", left, right)
+        if invoked:
+            self.registers[dst] = result
+        else:
+            # 整数整除，保持兼容
+            self.registers[dst] = left // right
 
     def _op_MOD(self, args):
-        self.registers[args[0]] = self.val(args[1]) % self.val(args[2])
+        dst, left_reg, right_reg = args
+        left = self.val(left_reg)
+        right = self.val(right_reg)
+        invoked, result = self._invoke_binary_metamethod("__mod", left, right)
+        if invoked:
+            self.registers[dst] = result
+        else:
+            self.registers[dst] = left % right
 
     def _op_CONCAT(self, args):
         dst, left_reg, right_reg = args
@@ -377,17 +412,44 @@ class BytecodeVM:
         self.registers[dst] = _coerce(left) + _coerce(right)
 
     def _op_NEG(self, args):
-        self.registers[args[0]] = -self.val(args[1])
+        dst, operand_reg = args
+        operand = self.val(operand_reg)
+        invoked, result = self._invoke_unary_metamethod(operand, "__unm")
+        if invoked:
+            self.registers[dst] = result
+        else:
+            self.registers[dst] = -operand
 
     # 逻辑运算
     def _op_EQ(self, args):
-        self.registers[args[0]] = self.val(args[1]) == self.val(args[2])
+        dst, left_reg, right_reg = args
+        left = self.val(left_reg)
+        right = self.val(right_reg)
+        invoked, result = self._invoke_eq_metamethod(left, right)
+        if invoked:
+            self.registers[dst] = bool(result)
+        else:
+            self.registers[dst] = left == right
 
     def _op_GT(self, args):
-        self.registers[args[0]] = self.val(args[1]) > self.val(args[2])
+        dst, left_reg, right_reg = args
+        left = self.val(left_reg)
+        right = self.val(right_reg)
+        invoked, result = self._invoke_compare_metamethod("__lt", right, left)
+        if invoked:
+            self.registers[dst] = bool(result)
+        else:
+            self.registers[dst] = left > right
 
     def _op_LT(self, args):
-        self.registers[args[0]] = self.val(args[1]) < self.val(args[2])
+        dst, left_reg, right_reg = args
+        left = self.val(left_reg)
+        right = self.val(right_reg)
+        invoked, result = self._invoke_compare_metamethod("__lt", left, right)
+        if invoked:
+            self.registers[dst] = bool(result)
+        else:
+            self.registers[dst] = left < right
 
     def _op_AND(self, args):
         self.registers[args[0]] = bool(self.val(args[1])) and bool(self.val(args[2]))
@@ -554,6 +616,158 @@ class BytecodeVM:
                 LuaTable = _LuaTable
         return LuaTable
 
+    def _is_callable_value(self, value) -> bool:
+        if isinstance(value, dict) and "label" in value:
+            return True
+        if getattr(value, "__lua_builtin__", False):
+            return True
+        return callable(value)
+
+    def _find_metamethod(self, value, name: str, *, allow_table: bool = False):
+        table_cls = self._resolve_lua_table()
+        if table_cls is None or not isinstance(value, table_cls):
+            return None
+
+        def enqueue(candidate, stack, seen):
+            if isinstance(candidate, table_cls):
+                ident = id(candidate)
+                if ident not in seen:
+                    seen.add(ident)
+                    stack.append(candidate)
+
+        seen: set[int] = set()
+        stack: list = []
+        metatable = value.get_metatable() if hasattr(value, "get_metatable") else getattr(value, "metatable", None)
+        enqueue(metatable, stack, seen)
+
+        while stack:
+            current = stack.pop()
+            handler = current.raw_get(name)
+            if handler is not None:
+                if allow_table:
+                    return handler
+                if self._is_callable_value(handler):
+                    return handler
+                return None
+
+            # Follow chained metatables (prototype-style inheritance).
+            next_meta = current.get_metatable() if hasattr(current, "get_metatable") else getattr(current, "metatable", None)
+            enqueue(next_meta, stack, seen)
+
+            # If __index points to another table, treat it as part of the lookup chain.
+            index_target = current.raw_get("__index")
+            enqueue(index_target, stack, seen)
+
+        return None
+
+    def _invoke_binary_metamethod(self, name: str, left, right):
+        handler = self._find_metamethod(left, name)
+        if handler is None:
+            handler = self._find_metamethod(right, name)
+        if handler is None or not self._is_callable_value(handler):
+            return False, None
+        result = self.call_callable(handler, [left, right])
+        value = result[0] if result else None
+        return True, value
+
+    def _invoke_unary_metamethod(self, operand, name: str):
+        handler = self._find_metamethod(operand, name)
+        if handler is None or not self._is_callable_value(handler):
+            return False, None
+        result = self.call_callable(handler, [operand])
+        value = result[0] if result else None
+        return True, value
+
+    def _invoke_compare_metamethod(self, name: str, left, right):
+        handler = self._find_metamethod(left, name)
+        if handler is None:
+            handler = self._find_metamethod(right, name)
+        if handler is None or not self._is_callable_value(handler):
+            return False, None
+        result = self.call_callable(handler, [left, right])
+        value = result[0] if result else None
+        return True, value
+
+    def _invoke_eq_metamethod(self, left, right):
+        left_handler = self._find_metamethod(left, "__eq")
+        right_handler = self._find_metamethod(right, "__eq")
+        handler = None
+        if left_handler is not None and right_handler is not None:
+            if left_handler is right_handler and self._is_callable_value(left_handler):
+                handler = left_handler
+        elif left_handler is not None and self._is_callable_value(left_handler):
+            handler = left_handler
+        elif right_handler is not None and self._is_callable_value(right_handler):
+            handler = right_handler
+        if handler is None:
+            return False, None
+        result = self.call_callable(handler, [left, right])
+        value = result[0] if result else None
+        return True, value
+
+    def _table_index_via_metatable(self, table, key):
+        table_cls = self._resolve_lua_table()
+        if table_cls is None:
+            return None
+        original = table
+        current = table
+        seen: set[int] = set()
+        while True:
+            value = current.raw_get(key)
+            if value is not None:
+                return value
+            metatable = current.get_metatable() if hasattr(current, "get_metatable") else getattr(current, "metatable", None)
+            if metatable is None or not isinstance(metatable, table_cls):
+                return None
+            handler = metatable.raw_get("__index")
+            if handler is None:
+                return None
+            if self._is_callable_value(handler):
+                result = self.call_callable(handler, [original, key])
+                return result[0] if result else None
+            if isinstance(handler, table_cls):
+                ident = id(handler)
+                if ident in seen:
+                    return None
+                seen.add(ident)
+                current = handler
+                continue
+            return None
+
+    def _apply_newindex(self, table, key, value) -> bool:
+        table_cls = self._resolve_lua_table()
+        if table_cls is None:
+            return False
+        original = table
+        current = table
+        seen: set[int] = set()
+        while True:
+            metatable = current.get_metatable() if hasattr(current, "get_metatable") else getattr(current, "metatable", None)
+            if metatable is None or not isinstance(metatable, table_cls):
+                if current is original:
+                    return False
+                current.raw_set(key, value)
+                return True
+            handler = metatable.raw_get("__newindex")
+            if handler is None:
+                if current is original:
+                    return False
+                current.raw_set(key, value)
+                return True
+            if self._is_callable_value(handler):
+                self.call_callable(handler, [current, key, value])
+                return True
+            if isinstance(handler, table_cls):
+                ident = id(handler)
+                if ident in seen:
+                    current.raw_set(key, value)
+                    return True
+                seen.add(ident)
+                current = handler
+                continue
+            current.raw_set(key, value)
+            return True
+
     def _ensure_table(self, value, reg_name: object):
         table_cls = self._resolve_lua_table()
         if table_cls is None or not isinstance(value, table_cls):
@@ -575,13 +789,22 @@ class BytecodeVM:
         table = self._ensure_table(self.val(table_reg), table_reg)
         key = self.val(key_arg)
         value = self.val(value_arg)
+        current = table.raw_get(key)
+        if current is not None:
+            table.raw_set(key, value)
+            return
+        if self._apply_newindex(table, key, value):
+            return
         table.raw_set(key, value)
 
     def _op_TABLE_GET(self, args):
         dst, table_reg, key_arg = args
         table = self._ensure_table(self.val(table_reg), table_reg)
         key = self.val(key_arg)
-        self.registers[dst] = table.raw_get(key)
+        value = table.raw_get(key)
+        if value is None:
+            value = self._table_index_via_metatable(table, key)
+        self.registers[dst] = value
 
     def _op_TABLE_APPEND(self, args):
         table_reg, value_arg = args

--- a/haifa_lua/stdlib.py
+++ b/haifa_lua/stdlib.py
@@ -88,6 +88,53 @@ def _is_lua_number(value: Any) -> bool:
     return isinstance(value, (int, float)) and not isinstance(value, bool)
 
 
+def _lua_setmetatable(args: Sequence[Any], vm: Any) -> LuaTable:  # noqa: ANN401
+    _ensure_args(args, 2, 2)
+    table = _ensure_table(args[0])
+    metatable_value = args[1]
+    if metatable_value is None:
+        table.set_metatable(None)
+        return table
+    metatable = _ensure_table(metatable_value)
+    table.set_metatable(metatable)
+    return table
+
+
+def _lua_getmetatable(args: Sequence[Any], vm: Any):  # noqa: ANN401
+    _ensure_args(args, 1, 1)
+    table = _ensure_table(args[0])
+    return table.get_metatable()
+
+
+def _lua_rawget(args: Sequence[Any], vm: Any):  # noqa: ANN401
+    _ensure_args(args, 2, 2)
+    table = _ensure_table(args[0])
+    return table.raw_get(args[1])
+
+
+def _lua_rawset(args: Sequence[Any], vm: Any) -> LuaTable:  # noqa: ANN401
+    _ensure_args(args, 3, 3)
+    table = _ensure_table(args[0])
+    table.raw_set(args[1], args[2])
+    return table
+
+
+def _lua_rawequal(args: Sequence[Any], vm: Any) -> bool:  # noqa: ANN401
+    _ensure_args(args, 2, 2)
+    left, right = args
+    if left is right:
+        return True
+    if left is None or right is None:
+        return False
+    if isinstance(left, bool) or isinstance(right, bool):
+        return left is right
+    if _is_lua_number(left) and _is_lua_number(right):
+        return float(left) == float(right)
+    if isinstance(left, LuaTable) and isinstance(right, LuaTable):
+        return left is right
+    return left == right
+
+
 def _lua_type(args: Sequence[Any], vm: Any) -> str:  # noqa: ANN401 - VM is dynamic
     _ensure_args(args, 1, 1)
     value = args[0]
@@ -462,6 +509,11 @@ def install_core_stdlib(env: LuaEnvironment) -> LuaEnvironment:
     env.register("assert", assert_builtin)
     env.register("pcall", pcall_builtin)
     env.register("xpcall", xpcall_builtin)
+    env.register("setmetatable", BuiltinFunction("setmetatable", _lua_setmetatable))
+    env.register("getmetatable", BuiltinFunction("getmetatable", _lua_getmetatable))
+    env.register("rawget", BuiltinFunction("rawget", _lua_rawget))
+    env.register("rawset", BuiltinFunction("rawset", _lua_rawset))
+    env.register("rawequal", BuiltinFunction("rawequal", _lua_rawequal))
 
     math_members = {
         "abs": BuiltinFunction("math.abs", _math_unary(lambda x: abs(x))),

--- a/haifa_lua/table.py
+++ b/haifa_lua/table.py
@@ -1,16 +1,19 @@
 from __future__ import annotations
 
-from typing import Any, Dict, Iterable, List
+from __future__ import annotations
+
+from typing import Any, Dict, Iterable, List, Optional
 
 
 class LuaTable:
     """Hybrid table supporting Lua-style array and dictionary access."""
 
-    __slots__ = ("array", "map", "__lua_table__")
+    __slots__ = ("array", "map", "metatable", "__lua_table__")
 
     def __init__(self, array: Iterable[Any] | None = None, mapping: Dict[Any, Any] | None = None) -> None:
         self.array: List[Any] = list(array) if array is not None else []
         self.map: Dict[Any, Any] = dict(mapping) if mapping is not None else {}
+        self.metatable: Optional["LuaTable"] = None
         self.__lua_table__ = True
 
     # ---------------------------- array helpers ---------------------------- #
@@ -73,6 +76,13 @@ class LuaTable:
             self.map.pop(key, None)
         else:
             self.map[key] = value
+
+    # ---------------------------- metatable helpers --------------------------- #
+    def set_metatable(self, metatable: "LuaTable" | None) -> None:
+        self.metatable = metatable
+
+    def get_metatable(self) -> "LuaTable" | None:
+        return self.metatable
 
 
     # ---------------------------- iteration helpers --------------------------- #

--- a/haifa_lua/tests/test_lua_metatables.py
+++ b/haifa_lua/tests/test_lua_metatables.py
@@ -1,0 +1,124 @@
+import pathlib
+import sys
+
+ROOT = pathlib.Path(__file__).resolve().parents[2]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from haifa_lua import run_source
+
+
+def test_method_definition_and_index_function():
+    src = """
+    local Account = { balance = 10 }
+
+    function Account:deposit(amount)
+        self.balance = self.balance + amount
+        return self
+    end
+
+    function Account:get_balance()
+        return self.balance
+    end
+
+    local dynamic = {}
+    function dynamic.__index(tbl, key)
+        if key == "bump" then
+            return function(self, value)
+                self.balance = self.balance + value * 2
+                return self.balance
+            end
+        end
+        return Account[key]
+    end
+
+    local user = { balance = 0 }
+    setmetatable(user, dynamic)
+
+    user:deposit(5)
+    local after_dynamic = user:bump(3)
+
+    return user.balance, after_dynamic, Account:get_balance(), getmetatable(user) == dynamic
+    """
+    result = run_source(src)
+    assert result == [11, 11, 10, True]
+
+
+def test_prototype_chain_and_arithmetic_metamethods():
+    src = """
+    local Vec = {}
+    Vec.__index = Vec
+
+    function Vec:new(x)
+        local instance = { x = x }
+        setmetatable(instance, self)
+        return instance
+    end
+
+    function Vec:__add(other)
+        return Vec:new(self.x + other.x)
+    end
+
+    function Vec:__eq(other)
+        return self.x == other.x
+    end
+
+    function Vec:__lt(other)
+        return self.x < other.x
+    end
+
+    function Vec:magnitude()
+        return self.x
+    end
+
+    local Child = {}
+    setmetatable(Child, { __index = Vec })
+
+    local a = Child:new(3)
+    local b = Child:new(7)
+    local c = a + b
+    local same = c == Child:new(10)
+    local diff = c == Child:new(8)
+    local lt = a < b
+    local gt = b > a
+
+    return c:magnitude(), same, diff, lt, gt, getmetatable(a) == Child
+    """
+    result = run_source(src)
+    assert result == [10, True, False, True, True, True]
+
+
+def test_newindex_and_raw_access_helpers():
+    src = """
+    local record = {}
+
+    local base = {}
+    setmetatable(base, {
+        __newindex = function(tbl, key, value)
+            record[key] = value .. "!"
+        end
+    })
+
+    local proxy = {}
+    setmetatable(proxy, { __newindex = base })
+
+    proxy.foo = "bar"
+    rawset(proxy, "foo", "raw")
+    rawset(proxy, "direct", 42)
+
+    local eq_meta = {
+        __eq = function(left, right)
+            return true
+        end
+    }
+    local left = {}
+    local right = {}
+    setmetatable(left, eq_meta)
+    setmetatable(right, eq_meta)
+    local eq_value = (left == right)
+    local raw_eq = rawequal(left, right)
+
+    return record.foo, rawget(proxy, "foo"), rawget(proxy, "direct"), eq_value, raw_eq
+    """
+    result = run_source(src)
+    assert result == ["bar!", "raw", 42, True, False]


### PR DESCRIPTION
## Summary
- support colon method definitions/calls and implicit self handling in the parser and compiler
- add Lua table metatable storage plus stdlib helpers for setmetatable/getmetatable/raw* APIs
- extend the bytecode VM with metamethod dispatch for arithmetic, comparison and property fallbacks; cover behaviour with new tests

## Testing
- `pytest haifa_lua/tests -q`


------
https://chatgpt.com/codex/tasks/task_e_68d4d24a7768832cb93d74c686e5af58