### PR TITLE
Add jq update assignments, control loops, and general reduce

### DIFF
--- a/compiler/tests/test_jq_expressions.py
+++ b/compiler/tests/test_jq_expressions.py
@@ -36,6 +36,37 @@ class TestJQExpressions(unittest.TestCase):
         data2 = {"a": 1, "b": 7}
         self.assertEqual(run_filter(".a // .b", data2), [1])
 
+    def test_update_assignment_pipe(self):
+        data = {"value": 3}
+        self.assertEqual(run_filter(".value |= . + 1", data), [{"value": 4}])
+
+    def test_update_compound_plus(self):
+        data = {"count": 5}
+        self.assertEqual(run_filter(".count += 7", data), [{"count": 12}])
+
+    def test_update_nested_index(self):
+        data = {"items": [1, 2, 3]}
+        result = run_filter(".items[1] += 5", data)
+        self.assertEqual(result, [{"items": [1, 7, 3]}])
+
+    def test_reduce_general(self):
+        expr = "reduce .nums[] as $n (0; . + $n)"
+        data = {"nums": [1, 2, 3]}
+        self.assertEqual(run_filter(expr, data), [6])
+
+    def test_foreach_with_extract(self):
+        expr = "foreach .nums[] as $n (0; . + $n; .)"
+        data = {"nums": [1, 2, 3]}
+        self.assertEqual(run_filter(expr, data), [1, 3, 6])
+
+    def test_while_loop(self):
+        result = run_filter("while(. < 10; . + 3)", 1)
+        self.assertEqual(result, [1, 4, 7])
+
+    def test_until_loop(self):
+        result = run_filter("until(. > 5; . + 2)", 1)
+        self.assertEqual(result, [1, 3, 5, 7])
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/docs/guide.md
+++ b/docs/guide.md
@@ -91,14 +91,22 @@ python -m compiler.jq_cli '.items | unique_by(.id)' --input people.json
 
 ### 5.4 聚合与 reduce
 ```bash
-python -m compiler.jq_cli '.values | reduce("sum")' --input numbers.json
+python -m compiler.jq_cli 'reduce .values[] as $n (0; . + $n)' --input numbers.json
 pyjq 'reduce(.items, "product")' --input numbers.json
+pyjq 'foreach .values[] as $n (0; . + $n; .)' --input numbers.json
 ```
 
 ### 5.5 字符串处理
 ```bash
 python -m compiler.jq_cli '.message | tostring' --input payload.json
 pyjq '.items | join(", ")' --input list.json
+```
+
+### 5.6 更新与循环组合子
+```bash
+python -m compiler.jq_cli '.counter += 1' --input counter.json
+pyjq 'while(. < 100; . * 2)' --input numbers.json
+pyjq 'until(. > 10; . + 3)' --input numbers.json
 ```
 
 ## 6. 类汇编脚本与可视化

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -122,19 +122,34 @@
 
 ### 3.2 `reduce` 语义
 
+通用形式：
+
+```jq
+reduce stream_expr as $item (init; update)
+```
+
+- `stream_expr`：生成要遍历的值，可为任意 jq 过滤器；
+- `init`：初始状态表达式，在外层输入上下文中求值；
+- `update`：更新表达式，`.` 绑定为累加器，`$item` 绑定为当前元素。
+
+兼容原有聚合器字符串形式：
+
 ```jq
 reduce(array_expr; op_string; init?)
 ```
 
-- `array_expr`：可选，若省略则使用当前输入。
-- `op_string`：`sum`, `product`, `min`, `max`, `concat` 等。
-- `init`：可选初始值。
-
 示例：
+
 ```bash
+pyjq 'reduce .items[] as $n (0; . + $n)' --input numbers.json
 pyjq 'reduce(.items; "sum")' --input numbers.json
 pyjq 'reduce(.items; "concat"; [])' --input arrays.json
 ```
+
+### 3.3 更新赋值与循环
+
+- 支持 `.path |= expr` 以及 `.path +=/-=/… expr` 等复合更新写法；
+- 新增 `foreach stream as $item (init; update; extract?)`，`while(cond; update)` 与 `until(cond; update)` 组合子。
 
 ## 4. 运行时行为
 
@@ -182,7 +197,6 @@ pyjq 'reduce(.items; "concat"; [])' --input arrays.json
 
 ## 9. 常见陷阱
 
-- `reduce` 的 aggregator 参数必须是字符串字面量；
 - `map` 和 `select` 内部表达式仍可使用管道；
 - 当输入为空数组，部分聚合返回 `None`（保持 jq 行为一致）。
 

--- a/haifa_jq/jq_ast.py
+++ b/haifa_jq/jq_ast.py
@@ -78,6 +78,13 @@ class BinaryOp(JQNode):
 
 
 @dataclass(frozen=True)
+class UpdateAssignment(JQNode):
+    target: JQNode
+    op: str  # currently "|=" for generic form
+    expr: JQNode
+
+
+@dataclass(frozen=True)
 class Index(JQNode):
     source: JQNode
     index: JQNode
@@ -101,6 +108,23 @@ class AsBinding(JQNode):
     name: str       # variable name without leading '$'
 
 
+@dataclass(frozen=True)
+class Reduce(JQNode):
+    source: JQNode
+    var_name: str
+    init: JQNode
+    update: JQNode
+
+
+@dataclass(frozen=True)
+class Foreach(JQNode):
+    source: JQNode
+    var_name: str
+    init: JQNode
+    update: JQNode
+    extract: Optional[JQNode]
+
+
 def flatten_pipe(expr: JQNode) -> List[JQNode]:
     """Expand a pipe tree into a flat left-to-right list."""
     if isinstance(expr, Pipe):
@@ -122,9 +146,12 @@ __all__ = [
     "ObjectLiteral",
     "UnaryOp",
     "BinaryOp",
+    "UpdateAssignment",
     "Index",
     "Slice",
     "VarRef",
     "AsBinding",
+    "Reduce",
+    "Foreach",
     "flatten_pipe",
 ]

--- a/haifa_jq/jq_bytecode.py
+++ b/haifa_jq/jq_bytecode.py
@@ -22,6 +22,7 @@ class JQOpcode(Enum):
     TRY_BEGIN = auto()
     TRY_END = auto()
     OBJ_SET = auto()
+    SET_INDEX = auto()
     FLATTEN = auto()
     REDUCE = auto()
 

--- a/haifa_jq/jq_vm.py
+++ b/haifa_jq/jq_vm.py
@@ -21,6 +21,7 @@ class JQVM(BytecodeVM):
             {
                 JQOpcode.OBJ_GET: self._op_OBJ_GET,
                 JQOpcode.OBJ_SET: self._op_OBJ_SET,
+                JQOpcode.SET_INDEX: self._op_SET_INDEX,
                 JQOpcode.GET_INDEX: self._op_GET_INDEX,
                 JQOpcode.LEN_VALUE: self._op_LEN_VALUE,
                 JQOpcode.PUSH_EMIT: self._op_PUSH_EMIT,
@@ -94,6 +95,23 @@ class JQVM(BytecodeVM):
             obj = {}
             self.registers[args[0]] = obj
         obj[args[1]] = self.val(args[2])
+
+    def _op_SET_INDEX(self, args):
+        container = self.registers.get(args[0])
+        index_value = self.val(args[1])
+        value = self.val(args[2])
+        if isinstance(container, list):
+            try:
+                idx = int(index_value)
+            except Exception:
+                return
+            length = len(container)
+            if idx < 0:
+                idx += length
+            if 0 <= idx < length:
+                container[idx] = value
+            elif idx == length:
+                container.append(value)
 
     def _op_GET_INDEX(self, args):
         container = self.val(args[1])


### PR DESCRIPTION
## Summary
- support jq update-assignment operators (|=, +=, etc.) by extending the parser, compiler, and VM
- implement general `reduce`/`foreach`/`while`/`until` combinators with new tests and documentation updates
- improve parser stop-handling to allow nested pipelines and add helpers for update paths

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d61cc868a4832c978eec629e944985