### PR TITLE
Improve pygame visualizer layout and scrolling

### DIFF
--- a/pygame/__init__.py
+++ b/pygame/__init__.py
@@ -118,6 +118,10 @@ K_UP = 273
 K_DOWN = 274
 K_LEFT = 276
 K_RIGHT = 275
+K_PAGEUP = 266
+K_PAGEDOWN = 267
+K_HOME = 278
+K_END = 279
 K_l = ord("l")
 K_r = ord("r")
 K_RETURN = 13
@@ -149,6 +153,10 @@ __all__ = [
     "K_DOWN",
     "K_LEFT",
     "K_RIGHT",
+    "K_PAGEUP",
+    "K_PAGEDOWN",
+    "K_HOME",
+    "K_END",
     "K_l",
     "K_r",
     "K_RETURN",


### PR DESCRIPTION
## Summary
- add a scrollable instruction list with range indicators and scrollbar feedback
- capture page navigation keys so the debugger can page through long bytecode listings
- expose new key constants in the pygame stub and document the new shortcuts in the footer help text

## Testing
- pytest test_chinese_gui.py

------
https://chatgpt.com/codex/tasks/task_e_68d725dadaf4832c987be1402445eaf0