### PR TITLE
Add package.searchpath and enforce protected metatables; improve module path search errors

### DIFF
--- a/haifa_lua/module_system.py
+++ b/haifa_lua/module_system.py
@@ -36,6 +36,10 @@ class LuaModuleSystem:
             "add_searcher",
             BuiltinFunction("package.add_searcher", self._lua_package_add_searcher),
         )
+        self.package_table.raw_set(
+            "searchpath",
+            BuiltinFunction("package.searchpath", self._lua_package_searchpath),
+        )
         self.base_path = pathlib.Path.cwd()
         self.module_envs: dict[str, LuaEnvironment] = {}
         self._install_default_searchers()
@@ -208,24 +212,32 @@ class LuaModuleSystem:
 
     def _search_lua_file(self, args: Sequence[object], vm: BytecodeVM) -> LuaMultiReturn:
         name = str(args[0]) if args else ""
-        module_path = name.replace(".", "/")
         path_value = self.package_table.raw_get("path")
         path_string = str(path_value) if path_value else "./?.lua;./?/init.lua"
+        resolved, error = self._search_path(name, path_string)
+        if resolved is None:
+            return LuaMultiReturn([None, error or "module not found"])
+        loader = BuiltinFunction(
+            f"module.loader[{name}]",
+            lambda loader_args, loader_vm, path=resolved: self._execute_module(path, name, loader_vm),
+        )
+        return LuaMultiReturn([loader, str(resolved)])
+
+    def _search_path(self, name: str, path_string: str) -> tuple[pathlib.Path | None, str | None]:
+        module_path = name.replace(".", "/")
+        attempted: list[str] = []
         for pattern in path_string.split(";"):
             pattern = pattern.strip()
             if not pattern:
                 continue
             candidate = pattern.replace("?", module_path)
             resolved = self.base_path / candidate
+            attempted.append(str(resolved))
             if resolved.is_file():
-                loader = BuiltinFunction(
-                    f"module.loader[{name}]",
-                    lambda loader_args, loader_vm, path=resolved: self._execute_module(
-                        path, name, loader_vm
-                    ),
-                )
-                return LuaMultiReturn([loader, str(resolved)])
-        return LuaMultiReturn([None, f"no file '{module_path}'" ])
+                return resolved, None
+        if not attempted:
+            return None, f"no file '{module_path}'"
+        return None, "\n".join(f"no file '{entry}'" for entry in attempted)
 
     def _execute_module(self, path: pathlib.Path, name: str, vm: BytecodeVM) -> LuaMultiReturn:
         source = path.read_text(encoding="utf-8")
@@ -344,6 +356,16 @@ class LuaModuleSystem:
         inherit = bool(args[2]) if len(args) >= 3 else False
         self.register_module_environment(name, env_value, inherit=inherit)
         return None
+
+    def _lua_package_searchpath(self, args: Sequence[object], vm: BytecodeVM) -> LuaMultiReturn:
+        if len(args) < 2:
+            raise RuntimeError("package.searchpath expects module name and path")
+        name = str(args[0])
+        path_string = str(args[1])
+        resolved, error = self._search_path(name, path_string)
+        if resolved is None:
+            return LuaMultiReturn([None, error or "module not found"])
+        return LuaMultiReturn([str(resolved)])
 
     def _lua_package_add_searcher(self, args: Sequence[object], vm: BytecodeVM) -> None:
         if not args:

--- a/haifa_lua/stdlib.py
+++ b/haifa_lua/stdlib.py
@@ -854,6 +854,9 @@ def _is_lua_number(value: Any) -> bool:
 def _lua_setmetatable(args: Sequence[Any], vm: Any) -> LuaTable:  # noqa: ANN401
     _ensure_args(args, 2, 2)
     table = _ensure_table(args[0])
+    existing = table.get_metatable()
+    if existing is not None and existing.raw_get("__metatable") is not None:
+        raise RuntimeError("cannot change a protected metatable")
     metatable_value = args[1]
     if metatable_value is None:
         table.set_metatable(None)
@@ -866,7 +869,13 @@ def _lua_setmetatable(args: Sequence[Any], vm: Any) -> LuaTable:  # noqa: ANN401
 def _lua_getmetatable(args: Sequence[Any], vm: Any):  # noqa: ANN401
     _ensure_args(args, 1, 1)
     table = _ensure_table(args[0])
-    return table.get_metatable()
+    metatable = table.get_metatable()
+    if metatable is None:
+        return None
+    protected = metatable.raw_get("__metatable")
+    if protected is not None:
+        return protected
+    return metatable
 
 
 def _lua_rawget(args: Sequence[Any], vm: Any):  # noqa: ANN401

--- a/haifa_lua/tests/test_lua_metatables.py
+++ b/haifa_lua/tests/test_lua_metatables.py
@@ -143,3 +143,17 @@ def test_call_and_len_metamethods():
     """
     result = run_source(src)
     assert result == [10.0, 42, "table"]
+
+
+def test_protected_metatable_blocks_reassignment():
+    src = """
+    local target = {}
+    local mt = { __metatable = "locked" }
+    setmetatable(target, mt)
+    local ok, err = pcall(function()
+        setmetatable(target, {})
+    end)
+    return getmetatable(target), ok, type(err) == "table", err.message ~= nil
+    """
+    result = run_source(src)
+    assert result == ["locked", False, True, True]

--- a/haifa_lua/tests/test_modules.py
+++ b/haifa_lua/tests/test_modules.py
@@ -94,3 +94,20 @@ def test_package_add_searcher_loads_custom_module(tmp_path: pathlib.Path) -> Non
     """
     result = run_source(script, env)
     assert result == [99.0]
+
+
+def test_package_searchpath_resolves_and_reports_errors(tmp_path: pathlib.Path) -> None:
+    module_path = tmp_path / "pkg" / "init.lua"
+    module_path.parent.mkdir(parents=True, exist_ok=True)
+    module_path.write_text("return true", encoding="utf-8")
+
+    env = create_default_environment()
+    env.module_system.set_base_path(tmp_path)  # type: ignore[attr-defined]
+
+    src = """
+local found = package.searchpath("pkg", "./?.lua;./?/init.lua")
+local missing, err = package.searchpath("absent", "./?.lua")
+return type(found), found ~= nil, missing == nil, type(err) == "string"
+"""
+    result = run_source(src, env)
+    assert result == ["string", True, True, True]


### PR DESCRIPTION
### Motivation
- Expose a `package.searchpath` helper to Lua code for resolving module filenames against a path string.
- Improve module search error messages by reporting attempted candidate paths when a file is not found.
- Prevent reassignment of a table's metatable when it has a protected `__metatable` entry and make `getmetatable` return the protected value.

### Description
- Added `package.searchpath` binding and implemented `_lua_package_searchpath` which uses a new helper `_search_path` to resolve module names against path patterns.
- Refactored `_search_lua_file` to call `_search_path` and construct a loader via `_execute_module` when a path is found, and made `_search_path` return detailed attempted-path errors.
- Updated `setmetatable` (`_lua_setmetatable`) to raise on reassignment if the existing metatable contains `__metatable`, and changed `getmetatable` (`_lua_getmetatable`) to return the protected `__metatable` value when present.
- Added tests `test_protected_metatable_blocks_reassignment` and `test_package_searchpath_resolves_and_reports_errors` to cover the new behaviors.

### Testing
- Ran the test suite with `pytest -q` including the new tests `tests/test_lua_metatables.py::test_protected_metatable_blocks_reassignment` and `tests/test_modules.py::test_package_searchpath_resolves_and_reports_errors`.
- The new tests passed and validated that `package.searchpath` resolves existing modules and reports missing candidates as strings.
- The metatable protection test passed and validated both blocking reassignment and returning the protected `__metatable` value from `getmetatable`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a071122593c832c8e2f7fb68aceaa82)